### PR TITLE
feat: モバイルデザイン完全対応

### DIFF
--- a/src/App.scss
+++ b/src/App.scss
@@ -565,10 +565,15 @@ body {
   }
 }
 
-// Mobile styles
+// =============================================================================
+// モバイル対応スタイル
+// =============================================================================
+
+// タブレット (768px以下)
 @media (max-width: 768px) {
   .app-header {
-    padding: 5px 12px;
+    padding: 8px 12px;
+    min-height: 48px;
   }
 
   .app-title {
@@ -576,13 +581,21 @@ body {
   }
 
   .header-actions {
-    gap: 4px;
+    gap: 6px;
   }
 
   .mode-toggle,
   .action-button {
-    padding: 4px 8px;
+    padding: 6px 10px;
     font-size: 11px;
+    min-height: 36px;
+  }
+
+  // タッチターゲット確保
+  .icon-button,
+  .help-button {
+    width: 36px;
+    height: 36px;
   }
 
   .app-main {
@@ -590,19 +603,299 @@ body {
   }
 
   .sidebar {
+    position: relative;
     width: 100%;
-    height: 40%;
+    height: 45%;
+    min-height: 200px;
+    max-height: 50vh;
     border-right: none;
-    border-bottom: 1px solid #e0e0e0;
+    border-bottom: 1px solid var(--color-border);
+
+    &.collapsed {
+      height: auto;
+      min-height: auto;
+      max-height: none;
+    }
+  }
+
+  .sidebar-toggle {
+    right: 10px;
+    top: auto;
+    bottom: -32px;
+    width: 36px;
+    height: 24px;
+    border-radius: 0 0 6px 6px;
   }
 
   .map-section {
-    height: 60%;
+    flex: 1;
+    height: auto;
+    min-height: 200px;
   }
 
   .draw-hint {
     top: 10px;
     padding: 10px 16px;
     font-size: 12px;
+    max-width: 90%;
+  }
+
+  // タブセクション
+  .tab {
+    padding: 10px 8px;
+    font-size: 12px;
+  }
+
+  .search-section-header {
+    padding: 8px 12px;
+  }
+
+  .search-section-content {
+    padding: 0 12px 12px;
+  }
+
+  // 通知
+  .notification {
+    left: 16px;
+    right: 16px;
+    transform: none;
+    text-align: center;
+    padding: 12px 16px;
+    font-size: 13px;
+  }
+
+  // モーダル
+  .modal-overlay {
+    padding: 16px;
+    align-items: flex-start;
+    padding-top: 10vh;
+  }
+
+  // ツールチップ非表示（モバイルでは不要）
+  [data-tooltip] {
+    &::before,
+    &::after {
+      display: none;
+    }
+  }
+}
+
+// 大型スマートフォン (600px以下)
+@media (max-width: 600px) {
+  .app-header {
+    padding: 6px 10px;
+    min-height: 44px;
+  }
+
+  .app-title {
+    font-size: 13px;
+  }
+
+  .header-divider {
+    margin: 0 2px;
+    height: 20px;
+  }
+
+  .mode-toggle,
+  .action-button {
+    padding: 5px 8px;
+    font-size: 10px;
+  }
+
+  .sidebar {
+    height: 40%;
+  }
+
+  .search-section-title {
+    font-size: 12px;
+  }
+
+  .collapsed-stat {
+    font-size: 11px;
+    padding: 5px 3px;
+  }
+}
+
+// 標準スマートフォン (480px以下)
+@media (max-width: 480px) {
+  .app-header {
+    padding: 6px 8px;
+    gap: 4px;
+  }
+
+  .app-title {
+    font-size: 12px;
+    max-width: 120px;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+  }
+
+  .header-actions {
+    gap: 3px;
+    flex-wrap: wrap;
+    justify-content: flex-end;
+  }
+
+  // 一部のボタンを非表示にするオプション
+  .header-actions .action-button:not(.essential) {
+    display: none;
+  }
+
+  .mode-toggle,
+  .action-button {
+    padding: 4px 6px;
+    font-size: 10px;
+    min-height: 32px;
+  }
+
+  .icon-button,
+  .help-button {
+    width: 32px;
+    height: 32px;
+  }
+
+  .sidebar {
+    height: 35%;
+    min-height: 180px;
+  }
+
+  .panel-tabs {
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+
+    .tab {
+      flex-shrink: 0;
+      padding: 8px 12px;
+    }
+  }
+
+  .notification {
+    bottom: 16px;
+    left: 8px;
+    right: 8px;
+    font-size: 12px;
+    padding: 10px 12px;
+  }
+
+  .draw-hint {
+    top: 8px;
+    padding: 8px 12px;
+    font-size: 11px;
+    border-radius: 6px;
+  }
+}
+
+// 小型スマートフォン (375px以下)
+@media (max-width: 375px) {
+  .app-title {
+    font-size: 11px;
+    max-width: 100px;
+  }
+
+  .sidebar {
+    height: 33%;
+    min-height: 160px;
+  }
+
+  .tab {
+    font-size: 11px;
+    padding: 6px 10px;
+  }
+}
+
+// 超小型スマートフォン (320px以下)
+@media (max-width: 320px) {
+  .app-header {
+    padding: 4px 6px;
+    min-height: 40px;
+  }
+
+  .app-title {
+    font-size: 10px;
+    max-width: 80px;
+  }
+
+  .mode-toggle,
+  .action-button {
+    padding: 3px 5px;
+    font-size: 9px;
+  }
+
+  .icon-button,
+  .help-button {
+    width: 28px;
+    height: 28px;
+  }
+
+  .sidebar {
+    min-height: 140px;
+  }
+}
+
+// ランドスケープモード対応
+@media (max-width: 768px) and (orientation: landscape) {
+  .app-main {
+    flex-direction: row;
+  }
+
+  .sidebar {
+    width: 40%;
+    height: 100%;
+    max-height: none;
+    border-right: 1px solid var(--color-border);
+    border-bottom: none;
+  }
+
+  .sidebar-toggle {
+    right: -32px;
+    top: 10px;
+    bottom: auto;
+    width: 24px;
+    height: 36px;
+    border-radius: 0 6px 6px 0;
+  }
+
+  .map-section {
+    flex: 1;
+    height: 100%;
+  }
+}
+
+// タッチデバイス最適化
+@media (hover: none) and (pointer: coarse) {
+  // ホバー効果を無効化
+  .icon-button:hover,
+  .mode-toggle:hover,
+  .action-button:hover,
+  .help-button:hover {
+    transform: none;
+  }
+
+  // タップ時のフィードバック
+  .icon-button:active,
+  .mode-toggle:active,
+  .action-button:active,
+  .help-button:active {
+    opacity: 0.7;
+    transform: scale(0.95);
+  }
+
+  // スクロール最適化
+  .panel-content {
+    -webkit-overflow-scrolling: touch;
+    overscroll-behavior: contain;
+  }
+}
+
+// セーフエリア対応 (ノッチ付きデバイス)
+@supports (padding: env(safe-area-inset-bottom)) {
+  .app {
+    padding-left: env(safe-area-inset-left);
+    padding-right: env(safe-area-inset-right);
+  }
+
+  .notification {
+    bottom: calc(16px + env(safe-area-inset-bottom));
   }
 }

--- a/src/components/ExportPanel/ExportPanel.module.scss
+++ b/src/components/ExportPanel/ExportPanel.module.scss
@@ -10,10 +10,29 @@
   display: flex;
   flex-direction: column;
 
+  // タブレット (768px以下)
   @media (max-width: 768px) {
     width: 95vw;
     min-width: auto;
     max-height: 90vh;
+    border-radius: 10px;
+  }
+
+  // 大型スマートフォン (600px以下)
+  @media (max-width: 600px) {
+    width: 98vw;
+    max-height: 95vh;
+    border-radius: 8px;
+    margin: 8px;
+  }
+
+  // 標準スマートフォン (480px以下)
+  @media (max-width: 480px) {
+    width: 100vw;
+    max-height: 100vh;
+    border-radius: 0;
+    margin: 0;
+    border: none;
   }
 }
 
@@ -382,5 +401,379 @@
 
   &:hover {
     background: #3aa3bc;
+  }
+}
+
+// =============================================================================
+// モバイル対応スタイル
+// =============================================================================
+
+// タブレット (768px以下)
+@media (max-width: 768px) {
+  .header {
+    padding: 14px 16px;
+
+    h3 {
+      font-size: 15px;
+    }
+  }
+
+  .backButton,
+  .closeButton {
+    width: 36px;
+    height: 36px;
+  }
+
+  .content {
+    padding: 16px;
+  }
+
+  .buttons {
+    flex-wrap: wrap;
+  }
+
+  .exportButton {
+    padding: 10px 14px;
+    font-size: 12px;
+    min-height: 44px;
+  }
+
+  .previewContent {
+    padding: 16px;
+    min-height: 250px;
+    max-height: 50vh;
+  }
+
+  .previewActions {
+    padding: 12px 16px;
+  }
+
+  .downloadButton {
+    padding: 10px 20px;
+    font-size: 13px;
+    min-height: 44px;
+  }
+}
+
+// 大型スマートフォン (600px以下)
+@media (max-width: 600px) {
+  .header {
+    padding: 12px 14px;
+
+    h3 {
+      font-size: 14px;
+    }
+  }
+
+  .content {
+    padding: 14px;
+  }
+
+  .section {
+    margin-bottom: 16px;
+
+    h4 {
+      font-size: 13px;
+    }
+  }
+
+  .count {
+    font-size: 12px;
+  }
+
+  .hint {
+    font-size: 11px;
+  }
+
+  .buttons {
+    gap: 8px;
+  }
+
+  .exportButton {
+    padding: 10px 12px;
+    font-size: 11px;
+    gap: 4px;
+  }
+
+  .previewContent {
+    padding: 12px;
+    min-height: 200px;
+  }
+
+  .jsonPreview pre {
+    font-size: 10px;
+    padding: 10px;
+  }
+
+  .csvPreview {
+    th, td {
+      padding: 6px 8px;
+      font-size: 11px;
+    }
+  }
+
+  .altitudeInputSection {
+    padding: 12px;
+
+    h4 {
+      font-size: 13px;
+    }
+  }
+
+  .altitudeRow {
+    padding: 6px 10px;
+    gap: 8px;
+  }
+
+  .altitudeLabel {
+    font-size: 12px;
+  }
+
+  .altitudeInput {
+    width: 70px;
+    padding: 6px 8px;
+    font-size: 13px;
+  }
+}
+
+// 標準スマートフォン (480px以下)
+@media (max-width: 480px) {
+  .header {
+    padding: 10px 12px;
+    position: sticky;
+    top: 0;
+    background: var(--color-bg-modal);
+    z-index: 10;
+
+    h3 {
+      font-size: 13px;
+    }
+  }
+
+  .backButton,
+  .closeButton {
+    width: 32px;
+    height: 32px;
+  }
+
+  .content {
+    padding: 12px;
+    overflow-y: auto;
+    -webkit-overflow-scrolling: touch;
+  }
+
+  .section {
+    margin-bottom: 14px;
+
+    h4 {
+      font-size: 12px;
+      margin-bottom: 6px;
+    }
+  }
+
+  .count {
+    font-size: 11px;
+    margin-bottom: 8px;
+  }
+
+  .hint {
+    font-size: 10px;
+    margin-bottom: 10px;
+  }
+
+  .buttons {
+    flex-direction: column;
+    gap: 6px;
+  }
+
+  .exportButton {
+    padding: 12px;
+    font-size: 12px;
+    justify-content: center;
+    min-height: 48px;
+  }
+
+  .previewContent {
+    padding: 10px;
+    min-height: 180px;
+    max-height: 45vh;
+    -webkit-overflow-scrolling: touch;
+  }
+
+  .jsonPreview pre {
+    font-size: 9px;
+    padding: 8px;
+    line-height: 1.4;
+  }
+
+  .csvPreview {
+    table {
+      font-size: 10px;
+    }
+
+    th, td {
+      padding: 5px 6px;
+    }
+  }
+
+  .notamPreview {
+    gap: 12px;
+  }
+
+  .altitudeInputSection {
+    padding: 10px;
+
+    h4 {
+      font-size: 12px;
+      margin-bottom: 10px;
+    }
+  }
+
+  .altitudeInputs {
+    gap: 8px;
+  }
+
+  .altitudeRow {
+    flex-wrap: wrap;
+    padding: 8px;
+    gap: 6px;
+  }
+
+  .altitudeColorDot {
+    width: 10px;
+    height: 10px;
+  }
+
+  .altitudeLabel {
+    font-size: 11px;
+    flex: 1 1 100%;
+    order: 1;
+  }
+
+  .altitudeInputWrapper {
+    order: 2;
+    margin-left: auto;
+  }
+
+  .altitudeInput {
+    width: 60px;
+    padding: 6px;
+    font-size: 12px;
+  }
+
+  .altitudeUnit {
+    font-size: 11px;
+  }
+
+  .notamContent pre {
+    padding: 12px;
+    font-size: 11px;
+    line-height: 1.6;
+  }
+
+  .truncateNote {
+    font-size: 11px;
+    padding: 6px 10px;
+  }
+
+  .previewActions {
+    padding: 12px;
+    position: sticky;
+    bottom: 0;
+    background: var(--color-bg-modal);
+  }
+
+  .downloadButton {
+    width: 100%;
+    justify-content: center;
+    padding: 12px 16px;
+    font-size: 13px;
+    min-height: 48px;
+  }
+}
+
+// 小型スマートフォン (375px以下)
+@media (max-width: 375px) {
+  .header {
+    padding: 8px 10px;
+
+    h3 {
+      font-size: 12px;
+    }
+  }
+
+  .content {
+    padding: 10px;
+  }
+
+  .exportButton {
+    font-size: 11px;
+    padding: 10px;
+  }
+
+  .altitudeInput {
+    width: 55px;
+    font-size: 11px;
+  }
+
+  .jsonPreview pre {
+    font-size: 8px;
+  }
+
+  .csvPreview {
+    font-size: 9px;
+
+    th, td {
+      padding: 4px 5px;
+    }
+  }
+}
+
+// 超小型スマートフォン (320px以下)
+@media (max-width: 320px) {
+  .header h3 {
+    font-size: 11px;
+  }
+
+  .exportButton {
+    font-size: 10px;
+    padding: 8px;
+    min-height: 44px;
+  }
+
+  .altitudeLabel {
+    font-size: 10px;
+  }
+
+  .altitudeInput {
+    width: 50px;
+    font-size: 10px;
+  }
+}
+
+// タッチデバイス最適化
+@media (hover: none) and (pointer: coarse) {
+  .exportButton:active,
+  .downloadButton:active {
+    opacity: 0.7;
+    transform: scale(0.98);
+  }
+
+  .previewContent {
+    -webkit-overflow-scrolling: touch;
+    overscroll-behavior: contain;
+  }
+
+  .csvPreview {
+    -webkit-overflow-scrolling: touch;
+  }
+}
+
+// セーフエリア対応
+@supports (padding: env(safe-area-inset-bottom)) {
+  @media (max-width: 480px) {
+    .previewActions {
+      padding-bottom: calc(12px + env(safe-area-inset-bottom));
+    }
   }
 }

--- a/src/components/FileImport/FileImport.module.scss
+++ b/src/components/FileImport/FileImport.module.scss
@@ -236,3 +236,254 @@
     background: var(--color-primary-dark);
   }
 }
+
+// =============================================================================
+// モバイル対応スタイル
+// =============================================================================
+
+// 大型スマートフォン (600px以下)
+@media (max-width: 600px) {
+  .fileImport {
+    border-radius: 10px;
+  }
+
+  .header {
+    padding: 12px 14px;
+
+    h3 {
+      font-size: 14px;
+    }
+  }
+
+  .closeButton {
+    width: 32px;
+    height: 32px;
+  }
+
+  .dropZone {
+    margin: 14px;
+    padding: 28px 20px;
+  }
+
+  .hint {
+    font-size: 12px;
+  }
+
+  .formats {
+    font-size: 11px;
+  }
+}
+
+// 標準スマートフォン (480px以下)
+@media (max-width: 480px) {
+  .fileImport {
+    width: 100vw;
+    max-width: 100vw;
+    border-radius: 0;
+    max-height: 100vh;
+  }
+
+  .header {
+    padding: 10px 12px;
+    position: sticky;
+    top: 0;
+    background: var(--color-bg-modal);
+    z-index: 10;
+
+    h3 {
+      font-size: 13px;
+    }
+  }
+
+  .closeButton {
+    width: 28px;
+    height: 28px;
+  }
+
+  .dropZone {
+    margin: 12px;
+    padding: 24px 16px;
+    border-radius: 6px;
+    min-height: 120px;
+  }
+
+  .dropContent p {
+    font-size: 13px;
+  }
+
+  .folderIcon {
+    width: 40px;
+    height: 40px;
+  }
+
+  .hint {
+    font-size: 11px;
+  }
+
+  .formats {
+    font-size: 10px;
+    margin-top: 12px !important;
+  }
+
+  .loading {
+    padding: 16px;
+    font-size: 13px;
+  }
+
+  .error {
+    margin: 0 12px 12px;
+    padding: 8px 12px;
+    font-size: 12px;
+  }
+
+  .preview {
+    padding: 12px;
+  }
+
+  .previewHeader {
+    margin-bottom: 12px;
+    flex-wrap: wrap;
+    gap: 8px;
+  }
+
+  .filename {
+    font-size: 13px;
+    word-break: break-all;
+    flex: 1 1 100%;
+  }
+
+  .polygonCount {
+    font-size: 11px;
+    padding: 3px 8px;
+  }
+
+  .previewList {
+    max-height: 160px;
+  }
+
+  .previewItem {
+    padding: 8px 10px;
+    gap: 8px;
+  }
+
+  .colorDot {
+    width: 8px;
+    height: 8px;
+  }
+
+  .polygonName {
+    font-size: 12px;
+  }
+
+  .vertexCount {
+    font-size: 10px;
+  }
+
+  .moreItems {
+    padding: 8px 10px;
+    font-size: 11px;
+  }
+
+  .actions {
+    gap: 10px;
+    margin-top: 16px;
+  }
+
+  .cancelButton,
+  .importButton {
+    padding: 12px;
+    font-size: 13px;
+    min-height: 48px;
+  }
+}
+
+// 小型スマートフォン (375px以下)
+@media (max-width: 375px) {
+  .header {
+    padding: 8px 10px;
+
+    h3 {
+      font-size: 12px;
+    }
+  }
+
+  .dropZone {
+    margin: 10px;
+    padding: 20px 12px;
+  }
+
+  .dropContent p {
+    font-size: 12px;
+  }
+
+  .folderIcon {
+    width: 36px;
+    height: 36px;
+  }
+
+  .hint {
+    font-size: 10px;
+  }
+
+  .preview {
+    padding: 10px;
+  }
+
+  .filename {
+    font-size: 12px;
+  }
+
+  .cancelButton,
+  .importButton {
+    padding: 10px;
+    font-size: 12px;
+  }
+}
+
+// 超小型スマートフォン (320px以下)
+@media (max-width: 320px) {
+  .dropZone {
+    padding: 16px 10px;
+  }
+
+  .hint {
+    font-size: 9px;
+  }
+
+  .formats {
+    font-size: 9px;
+  }
+}
+
+// タッチデバイス最適化
+@media (hover: none) and (pointer: coarse) {
+  .dropZone {
+    // タッチでのアップロードを促すテキスト表示
+    min-height: 140px;
+  }
+
+  .dropZone:active {
+    background: var(--color-primary-bg);
+    border-color: var(--color-primary);
+  }
+
+  .cancelButton:active,
+  .importButton:active {
+    transform: scale(0.98);
+    opacity: 0.8;
+  }
+
+  .previewList {
+    -webkit-overflow-scrolling: touch;
+    overscroll-behavior: contain;
+  }
+}
+
+// セーフエリア対応
+@supports (padding: env(safe-area-inset-bottom)) {
+  @media (max-width: 480px) {
+    .actions {
+      padding-bottom: env(safe-area-inset-bottom);
+    }
+  }
+}

--- a/src/components/FlightAssistant/FlightAssistant.scss
+++ b/src/components/FlightAssistant/FlightAssistant.scss
@@ -1370,17 +1370,580 @@
   }
 }
 
-// Responsive
-@media (max-width: 480px) {
+// =============================================================================
+// モバイル対応スタイル
+// =============================================================================
+
+// タブレット (768px以下)
+@media (max-width: 768px) {
   .flight-assistant {
-    width: calc(100vw - 32px);
-    max-height: calc(100vh - 100px);
+    width: 360px;
+    min-width: 320px;
+    max-height: calc(100vh - 80px);
+    bottom: 16px;
+    right: 16px;
+
+    &.expanded {
+      width: min(90vw, 600px);
+    }
+
+    &.fullscreen {
+      top: 50px;
+      width: 90vw !important;
+      max-width: none;
+      max-height: calc(100vh - 66px);
+    }
+  }
+
+  .flight-assistant-fab {
+    width: 52px;
+    height: 52px;
     bottom: 16px;
     right: 16px;
   }
 
+  .flight-assistant-header {
+    padding: 8px 10px;
+    min-height: 42px;
+
+    .header-title {
+      font-size: 12px;
+    }
+
+    .header-actions button {
+      width: 32px;
+      height: 32px;
+    }
+  }
+
+  .flight-assistant-messages {
+    padding: 10px;
+    gap: 8px;
+  }
+
+  .message .message-content {
+    max-width: 85%;
+    padding: 8px 12px;
+    font-size: 13px;
+
+    table {
+      font-size: 10px;
+    }
+  }
+
+  .flight-assistant-input {
+    padding: 6px 10px;
+
+    textarea {
+      font-size: 14px;
+      padding: 10px;
+    }
+
+    .send-btn {
+      width: 44px;
+      height: 44px;
+    }
+  }
+
+  .flight-assistant-actions {
+    padding: 6px 8px;
+    flex-wrap: wrap;
+    gap: 4px;
+
+    .assessment-btn {
+      padding: 8px 10px;
+      font-size: 11px;
+      flex: 1;
+      min-height: 36px;
+    }
+
+    .icon-btn {
+      width: 36px;
+      height: 36px;
+    }
+  }
+}
+
+// 大型スマートフォン (600px以下)
+@media (max-width: 600px) {
+  .flight-assistant {
+    width: calc(100vw - 24px);
+    min-width: auto;
+    right: 12px;
+    bottom: 12px;
+    max-height: calc(100vh - 70px);
+
+    &.expanded {
+      width: calc(100vw - 24px);
+    }
+
+    &.fullscreen {
+      top: 44px;
+      left: 8px;
+      right: 8px;
+      bottom: 8px;
+      width: auto !important;
+      max-height: none;
+      border-radius: 12px;
+    }
+  }
+
   .flight-assistant-fab {
-    bottom: 16px;
-    right: 16px;
+    width: 48px;
+    height: 48px;
+    bottom: 12px;
+    right: 12px;
+  }
+
+  .chat-logs-panel {
+    max-height: 160px;
+
+    .chat-log-item {
+      padding: 6px 10px;
+    }
+  }
+
+  .avoidance-settings {
+    padding: 8px 10px;
+
+    .avoidance-toggles {
+      gap: 8px;
+
+      .toggle-item {
+        font-size: 10px;
+      }
+    }
+  }
+
+  .settings-panel {
+    max-height: 180px;
+
+    .settings-header {
+      padding: 6px 10px;
+    }
+
+    .settings-content {
+      padding: 6px 10px;
+    }
+  }
+}
+
+// 標準スマートフォン (480px以下)
+@media (max-width: 480px) {
+  .flight-assistant {
+    width: calc(100vw - 16px);
+    right: 8px;
+    bottom: 8px;
+    border-radius: 12px;
+    max-height: calc(100vh - 80px);
+
+    &.fullscreen {
+      top: 40px;
+      left: 4px;
+      right: 4px;
+      bottom: 4px;
+      border-radius: 10px;
+    }
+  }
+
+  .flight-assistant-fab {
+    width: 44px;
+    height: 44px;
+    bottom: 10px;
+    right: 10px;
+
+    svg {
+      width: 20px;
+      height: 20px;
+    }
+  }
+
+  .flight-assistant-header {
+    padding: 6px 8px;
+    min-height: 40px;
+
+    .drag-handle {
+      display: none;
+    }
+
+    .header-title {
+      font-size: 11px;
+      gap: 3px;
+
+      .ai-badge,
+      .mlit-badge {
+        font-size: 8px;
+        padding: 1px 3px;
+      }
+    }
+
+    .header-actions {
+      gap: 0;
+
+      button {
+        width: 28px;
+        height: 28px;
+        padding: 4px;
+      }
+    }
+  }
+
+  .flight-assistant-messages {
+    padding: 8px;
+    gap: 6px;
+
+    .message .message-content {
+      max-width: 90%;
+      padding: 6px 10px;
+      font-size: 12px;
+      line-height: 1.4;
+
+      h3 {
+        font-size: 13px;
+      }
+
+      h4 {
+        font-size: 12px;
+      }
+
+      .table-wrapper {
+        margin: 6px 0;
+      }
+
+      table {
+        font-size: 9px;
+
+        th, td {
+          padding: 4px 5px;
+        }
+      }
+
+      .apply-route-btn {
+        padding: 8px 10px;
+        font-size: 11px;
+      }
+
+      .wp-link {
+        padding: 0 4px;
+        font-size: 10px;
+      }
+    }
+
+    .message-avatar {
+      width: 24px;
+      height: 24px;
+      min-width: 24px;
+    }
+  }
+
+  .flight-assistant-input {
+    padding: 6px 8px;
+    gap: 4px;
+
+    textarea {
+      font-size: 14px; // 16px以上でズーム防止
+      padding: 8px;
+      border-radius: 8px;
+      min-height: 40px;
+    }
+
+    .send-btn {
+      width: 40px;
+      height: 40px;
+      border-radius: 8px;
+    }
+  }
+
+  .flight-assistant-actions {
+    padding: 4px 6px;
+
+    .assessment-btn {
+      padding: 6px 8px;
+      font-size: 10px;
+      min-height: 32px;
+    }
+
+    .icon-btn {
+      width: 32px;
+      height: 32px;
+    }
+
+    .action-info {
+      font-size: 9px;
+    }
+  }
+
+  .assessment-summary {
+    .summary-header {
+      padding: 5px 8px;
+
+      > span:first-child {
+        font-size: 10px;
+      }
+
+      .score {
+        font-size: 9px;
+      }
+    }
+
+    .summary-detail {
+      padding: 3px 8px 6px;
+      gap: 4px 8px;
+
+      .detail-row {
+        font-size: 10px;
+      }
+    }
+  }
+
+  .risk-badge {
+    padding: 3px 6px;
+    font-size: 10px;
+  }
+
+  .avoidance-settings {
+    padding: 6px 8px;
+
+    .avoidance-slider {
+      label {
+        font-size: 11px;
+
+        strong {
+          font-size: 12px;
+        }
+      }
+
+      .slider-ticks {
+        font-size: 8px;
+      }
+    }
+
+    .avoidance-toggles {
+      gap: 6px;
+
+      .toggle-item {
+        font-size: 9px;
+        gap: 3px;
+
+        input[type="checkbox"] {
+          width: 12px;
+          height: 12px;
+        }
+      }
+    }
+  }
+
+  .optimization-panel {
+    max-height: 100px;
+
+    .optimization-header {
+      padding: 6px 10px;
+      font-size: 11px;
+    }
+
+    .optimization-content {
+      padding: 6px 10px;
+
+      .optimization-summary {
+        font-size: 10px;
+      }
+
+      .optimization-actions {
+        font-size: 10px;
+      }
+
+      .apply-optimization-btn {
+        padding: 6px 10px;
+        font-size: 11px;
+      }
+    }
+  }
+
+  .chat-logs-panel {
+    max-height: 140px;
+
+    .chat-logs-header {
+      padding: 8px 12px;
+
+      h3 {
+        font-size: 12px;
+      }
+    }
+
+    .chat-log-item {
+      .log-info .log-name {
+        font-size: 11px;
+      }
+
+      .log-info .log-date {
+        font-size: 9px;
+      }
+    }
+  }
+
+  .settings-panel {
+    max-height: 150px;
+
+    .settings-section h4 {
+      font-size: 11px;
+    }
+
+    .api-key-input input {
+      font-size: 12px;
+      padding: 6px 8px;
+    }
+
+    .model-selector {
+      label {
+        font-size: 11px;
+      }
+
+      select {
+        font-size: 11px;
+        padding: 4px 8px;
+      }
+    }
+  }
+}
+
+// 小型スマートフォン (375px以下)
+@media (max-width: 375px) {
+  .flight-assistant {
+    width: calc(100vw - 12px);
+    right: 6px;
+    bottom: 6px;
+    border-radius: 10px;
+  }
+
+  .flight-assistant-fab {
+    width: 40px;
+    height: 40px;
+    bottom: 8px;
+    right: 8px;
+  }
+
+  .flight-assistant-header {
+    .header-title {
+      font-size: 10px;
+
+      .ai-badge,
+      .mlit-badge {
+        display: none;
+      }
+    }
+
+    .header-actions button {
+      width: 26px;
+      height: 26px;
+    }
+  }
+
+  .message .message-content {
+    font-size: 11px;
+    padding: 5px 8px;
+  }
+
+  .flight-assistant-input textarea {
+    font-size: 14px;
+    padding: 6px;
+  }
+}
+
+// 超小型スマートフォン (320px以下)
+@media (max-width: 320px) {
+  .flight-assistant {
+    width: calc(100vw - 8px);
+    right: 4px;
+    bottom: 4px;
+  }
+
+  .flight-assistant-fab {
+    width: 36px;
+    height: 36px;
+    bottom: 6px;
+    right: 6px;
+  }
+
+  .flight-assistant-header {
+    padding: 4px 6px;
+    min-height: 36px;
+
+    .header-actions button {
+      width: 24px;
+      height: 24px;
+    }
+  }
+}
+
+// ランドスケープモード対応
+@media (max-width: 768px) and (orientation: landscape) {
+  .flight-assistant {
+    max-height: calc(100vh - 32px);
+    width: 50vw;
+    min-width: 300px;
+
+    &.fullscreen {
+      top: 8px;
+      width: 70vw !important;
+    }
+  }
+
+  .flight-assistant-fab {
+    bottom: 12px;
+    right: 12px;
+  }
+}
+
+// タッチデバイス最適化
+@media (hover: none) and (pointer: coarse) {
+  .flight-assistant-fab:hover {
+    transform: none;
+  }
+
+  .flight-assistant-fab:active {
+    transform: scale(0.95);
+  }
+
+  .flight-assistant-header .header-actions button:active {
+    background: rgba(255, 255, 255, 0.3);
+  }
+
+  .flight-assistant-input .send-btn:active {
+    transform: scale(0.95);
+  }
+
+  // スクロール最適化
+  .flight-assistant-messages {
+    -webkit-overflow-scrolling: touch;
+    overscroll-behavior: contain;
+  }
+
+  .chat-logs-panel .chat-logs-list {
+    -webkit-overflow-scrolling: touch;
+  }
+}
+
+// セーフエリア対応
+@supports (padding: env(safe-area-inset-bottom)) {
+  .flight-assistant {
+    bottom: calc(16px + env(safe-area-inset-bottom));
+    right: calc(16px + env(safe-area-inset-right));
+  }
+
+  .flight-assistant-fab {
+    bottom: calc(16px + env(safe-area-inset-bottom));
+    right: calc(16px + env(safe-area-inset-right));
+  }
+
+  @media (max-width: 480px) {
+    .flight-assistant {
+      bottom: calc(8px + env(safe-area-inset-bottom));
+      right: calc(8px + env(safe-area-inset-right));
+    }
+
+    .flight-assistant-fab {
+      bottom: calc(10px + env(safe-area-inset-bottom));
+      right: calc(10px + env(safe-area-inset-right));
+    }
   }
 }

--- a/src/components/GridSettingsDialog/GridSettingsDialog.module.scss
+++ b/src/components/GridSettingsDialog/GridSettingsDialog.module.scss
@@ -365,3 +365,355 @@
     cursor: not-allowed;
   }
 }
+
+// =============================================================================
+// モバイル対応スタイル
+// =============================================================================
+
+// タブレット (768px以下)
+@media (max-width: 768px) {
+  .dialog {
+    width: 95vw;
+    max-width: 400px;
+  }
+
+  .header {
+    padding: 14px 16px;
+  }
+
+  .titleRow h3 {
+    font-size: 15px;
+  }
+
+  .closeButton {
+    width: 32px;
+    height: 32px;
+  }
+
+  .content {
+    padding: 16px;
+  }
+
+  .presetButton {
+    padding: 8px 14px;
+    font-size: 12px;
+    min-height: 36px;
+  }
+
+  .actions {
+    padding: 14px 16px;
+  }
+
+  .cancelButton,
+  .confirmButton {
+    padding: 14px 16px;
+    min-height: 48px;
+  }
+}
+
+// 標準スマートフォン (480px以下)
+@media (max-width: 480px) {
+  .dialog {
+    width: 100vw;
+    max-width: 100vw;
+    max-height: 100vh;
+    border-radius: 0;
+  }
+
+  .header {
+    padding: 12px 14px;
+    position: sticky;
+    top: 0;
+    z-index: 10;
+  }
+
+  .titleRow {
+    gap: 8px;
+
+    svg {
+      width: 20px;
+      height: 20px;
+    }
+
+    h3 {
+      font-size: 14px;
+    }
+  }
+
+  .closeButton {
+    width: 28px;
+    height: 28px;
+  }
+
+  .content {
+    padding: 14px;
+    overflow-y: auto;
+    -webkit-overflow-scrolling: touch;
+    max-height: calc(100vh - 120px);
+  }
+
+  .polygonInfo {
+    padding: 10px 14px;
+    margin-bottom: 16px;
+    gap: 6px;
+  }
+
+  .colorDot {
+    width: 10px;
+    height: 10px;
+  }
+
+  .polygonName {
+    font-size: 13px;
+  }
+
+  .polygonArea {
+    font-size: 12px;
+  }
+
+  .settingGroup {
+    margin-bottom: 16px;
+  }
+
+  .label {
+    font-size: 13px;
+    margin-bottom: 6px;
+  }
+
+  .unit {
+    font-size: 11px;
+  }
+
+  .spacingInput {
+    gap: 6px;
+    margin-bottom: 10px;
+  }
+
+  .numberInput {
+    width: 90px;
+    padding: 8px 10px;
+    font-size: 16px; // ズーム防止
+    border-radius: 6px;
+  }
+
+  .inputUnit {
+    font-size: 14px;
+  }
+
+  .spacingPresets {
+    flex-wrap: wrap;
+    gap: 6px;
+    margin-bottom: 10px;
+  }
+
+  .presetButton {
+    padding: 6px 10px;
+    font-size: 11px;
+    min-height: 32px;
+  }
+
+  .slider {
+    height: 8px;
+
+    &::-webkit-slider-thumb {
+      width: 24px;
+      height: 24px;
+    }
+
+    &::-moz-range-thumb {
+      width: 24px;
+      height: 24px;
+    }
+  }
+
+  .sliderLabels {
+    font-size: 10px;
+  }
+
+  .checkboxLabel {
+    gap: 6px;
+
+    input[type="checkbox"] {
+      width: 20px;
+      height: 20px;
+    }
+
+    span {
+      font-size: 13px;
+    }
+  }
+
+  .preview {
+    padding: 12px;
+    border-radius: 6px;
+
+    h4 {
+      font-size: 12px;
+      margin-bottom: 10px;
+    }
+  }
+
+  .countGrid {
+    gap: 8px;
+    margin-bottom: 10px;
+  }
+
+  .countItem {
+    padding: 10px 8px;
+  }
+
+  .countLabel {
+    font-size: 10px;
+  }
+
+  .countValue {
+    font-size: 20px;
+  }
+
+  .alert {
+    padding: 10px;
+    font-size: 11px;
+    gap: 8px;
+    border-radius: 6px;
+
+    svg {
+      width: 16px;
+      height: 16px;
+    }
+  }
+
+  .actions {
+    padding: 12px 14px;
+    gap: 10px;
+    position: sticky;
+    bottom: 0;
+  }
+
+  .cancelButton {
+    padding: 12px 16px;
+    font-size: 13px;
+    min-height: 48px;
+  }
+
+  .confirmButton {
+    padding: 12px 16px;
+    font-size: 13px;
+    gap: 6px;
+    min-height: 48px;
+  }
+}
+
+// 小型スマートフォン (375px以下)
+@media (max-width: 375px) {
+  .header {
+    padding: 10px 12px;
+  }
+
+  .titleRow h3 {
+    font-size: 13px;
+  }
+
+  .content {
+    padding: 12px;
+  }
+
+  .polygonInfo {
+    padding: 8px 12px;
+  }
+
+  .polygonName {
+    font-size: 12px;
+  }
+
+  .numberInput {
+    width: 80px;
+    font-size: 15px;
+  }
+
+  .presetButton {
+    font-size: 10px;
+    padding: 5px 8px;
+  }
+
+  .countValue {
+    font-size: 18px;
+  }
+
+  .cancelButton,
+  .confirmButton {
+    font-size: 12px;
+    padding: 10px 14px;
+  }
+}
+
+// 超小型スマートフォン (320px以下)
+@media (max-width: 320px) {
+  .spacingPresets {
+    flex-direction: column;
+  }
+
+  .presetButton {
+    width: 100%;
+    text-align: center;
+  }
+
+  .numberInput {
+    width: 70px;
+    font-size: 14px;
+  }
+
+  .countGrid {
+    grid-template-columns: repeat(2, 1fr);
+  }
+}
+
+// タッチデバイス最適化
+@media (hover: none) and (pointer: coarse) {
+  .closeButton:active {
+    background: #d0d0d0;
+    transform: scale(0.95);
+  }
+
+  .presetButton:active {
+    transform: scale(0.95);
+    opacity: 0.8;
+  }
+
+  .cancelButton:active,
+  .confirmButton:active {
+    transform: scale(0.98);
+    opacity: 0.8;
+  }
+
+  .slider {
+    height: 10px;
+
+    &::-webkit-slider-thumb {
+      width: 28px;
+      height: 28px;
+    }
+
+    &::-moz-range-thumb {
+      width: 28px;
+      height: 28px;
+    }
+  }
+
+  .checkboxLabel input[type="checkbox"] {
+    width: 24px;
+    height: 24px;
+  }
+
+  .content {
+    -webkit-overflow-scrolling: touch;
+  }
+}
+
+// セーフエリア対応
+@supports (padding: env(safe-area-inset-bottom)) {
+  @media (max-width: 480px) {
+    .actions {
+      padding-bottom: calc(12px + env(safe-area-inset-bottom));
+    }
+  }
+}

--- a/src/components/HelpModal/HelpModal.module.scss
+++ b/src/components/HelpModal/HelpModal.module.scss
@@ -336,12 +336,30 @@
   font-style: italic;
 }
 
-// Mobile responsive
+// =============================================================================
+// モバイル対応スタイル
+// =============================================================================
+
+// タブレット (768px以下)
 @media (max-width: 768px) {
   .modal {
     width: 95vw;
     height: 90vh;
     max-height: none;
+    border-radius: 10px;
+  }
+
+  .header {
+    padding: 14px 20px;
+
+    h1 {
+      font-size: 16px;
+    }
+  }
+
+  .closeButton {
+    width: 36px;
+    height: 36px;
   }
 
   .body {
@@ -356,11 +374,13 @@
     display: flex;
     overflow-x: auto;
     flex-shrink: 0;
+    -webkit-overflow-scrolling: touch;
   }
 
   .navItem {
     padding: 10px 16px;
     white-space: nowrap;
+    min-height: 44px;
 
     .chevron {
       display: none;
@@ -369,10 +389,372 @@
 
   .content {
     padding: 20px;
+    -webkit-overflow-scrolling: touch;
   }
 
   .featureList {
     grid-template-columns: 1fr;
+  }
+
+  .section {
+    h2 {
+      font-size: 18px;
+    }
+
+    h3 {
+      font-size: 14px;
+    }
+  }
+
+  .table, .shortcutTable {
+    font-size: 12px;
+
+    th, td {
+      padding: 8px 10px;
+    }
+  }
+}
+
+// 大型スマートフォン (600px以下)
+@media (max-width: 600px) {
+  .modal {
+    width: 98vw;
+    height: 95vh;
+    border-radius: 8px;
+  }
+
+  .header {
+    padding: 12px 16px;
+
+    h1 {
+      font-size: 15px;
+    }
+  }
+
+  .nav {
+    padding: 6px 0;
+  }
+
+  .navItem {
+    padding: 8px 14px;
+    font-size: 13px;
+    min-height: 40px;
+  }
+
+  .content {
+    padding: 16px;
+  }
+
+  .section {
+    h2 {
+      font-size: 16px;
+      margin-bottom: 16px;
+    }
+
+    h3 {
+      font-size: 13px;
+      margin: 16px 0 10px;
+    }
+
+    p {
+      font-size: 13px;
+    }
+
+    ul, ol {
+      li {
+        font-size: 13px;
+      }
+    }
+  }
+
+  .lead {
+    font-size: 14px !important;
+    padding: 12px;
+  }
+
+  .featureList li {
+    padding: 12px;
+
+    strong {
+      font-size: 13px;
+    }
+
+    span {
+      font-size: 11px;
+    }
+  }
+
+  .table, .shortcutTable {
+    font-size: 11px;
+
+    th, td {
+      padding: 6px 8px;
+    }
+
+    kbd {
+      font-size: 10px;
+      padding: 3px 6px;
+    }
+  }
+
+  .shortcutTable td:first-child {
+    width: 120px;
+  }
+}
+
+// 標準スマートフォン (480px以下)
+@media (max-width: 480px) {
+  .modal {
+    width: 100vw;
+    height: 100vh;
+    max-height: 100vh;
+    border-radius: 0;
+  }
+
+  .header {
+    padding: 10px 14px;
+    position: sticky;
+    top: 0;
+    background: var(--color-bg-secondary);
+    z-index: 10;
+
+    h1 {
+      font-size: 14px;
+    }
+  }
+
+  .closeButton {
+    width: 32px;
+    height: 32px;
+  }
+
+  .nav {
+    padding: 4px 0;
+    position: sticky;
+    top: 52px;
+    background: var(--color-bg-secondary);
+    z-index: 10;
+  }
+
+  .navItem {
+    padding: 8px 12px;
+    font-size: 12px;
+    min-height: 36px;
+  }
+
+  .content {
+    padding: 14px;
+  }
+
+  .section {
+    h2 {
+      font-size: 15px;
+      margin-bottom: 14px;
+      padding-bottom: 10px;
+    }
+
+    h3 {
+      font-size: 12px;
+      margin: 14px 0 8px;
+    }
+
+    p {
+      font-size: 12px;
+      line-height: 1.6;
+      margin-bottom: 10px;
+    }
+
+    ul, ol {
+      padding-left: 16px;
+      margin-bottom: 12px;
+
+      li {
+        font-size: 12px;
+        margin-bottom: 6px;
+      }
+    }
+  }
+
+  .lead {
+    font-size: 13px !important;
+    padding: 10px;
+    border-left-width: 3px;
+  }
+
+  .featureList {
+    gap: 8px;
+
+    li {
+      padding: 10px;
+      gap: 10px;
+
+      svg {
+        width: 18px;
+        height: 18px;
+      }
+
+      strong {
+        font-size: 12px;
+      }
+
+      span {
+        font-size: 10px;
+      }
+    }
+  }
+
+  .stepList li {
+    padding-left: 30px;
+    margin-bottom: 10px !important;
+
+    &::before {
+      width: 20px;
+      height: 20px;
+      font-size: 10px;
+    }
+  }
+
+  // テーブルを横スクロール可能に
+  .table, .shortcutTable {
+    display: block;
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+    font-size: 10px;
+
+    th, td {
+      padding: 5px 6px;
+    }
+
+    kbd {
+      font-size: 9px;
+      padding: 2px 4px;
+      margin-right: 2px;
+    }
+  }
+
+  .shortcutTable td:first-child {
+    width: 100px;
+    min-width: 100px;
+  }
+
+  .warning {
+    padding: 10px 12px;
+    font-size: 11px;
+  }
+
+  .hint {
+    font-size: 11px !important;
+  }
+}
+
+// 小型スマートフォン (375px以下)
+@media (max-width: 375px) {
+  .header {
+    padding: 8px 12px;
+
+    h1 {
+      font-size: 13px;
+    }
+  }
+
+  .navItem {
+    padding: 6px 10px;
+    font-size: 11px;
+  }
+
+  .content {
+    padding: 12px;
+  }
+
+  .section {
+    h2 {
+      font-size: 14px;
+    }
+
+    p, li {
+      font-size: 11px;
+    }
+  }
+
+  .featureList li {
+    padding: 8px;
+
+    strong {
+      font-size: 11px;
+    }
+
+    span {
+      font-size: 9px;
+    }
+  }
+
+  .table, .shortcutTable {
+    font-size: 9px;
+
+    th, td {
+      padding: 4px 5px;
+    }
+
+    kbd {
+      font-size: 8px;
+      padding: 1px 3px;
+    }
+  }
+}
+
+// 超小型スマートフォン (320px以下)
+@media (max-width: 320px) {
+  .header h1 {
+    font-size: 12px;
+  }
+
+  .navItem {
+    font-size: 10px;
+    padding: 5px 8px;
+  }
+
+  .section {
+    h2 {
+      font-size: 13px;
+    }
+
+    p, li {
+      font-size: 10px;
+    }
+  }
+
+  .table, .shortcutTable {
+    font-size: 8px;
+  }
+}
+
+// タッチデバイス最適化
+@media (hover: none) and (pointer: coarse) {
+  .navItem:active {
+    background: var(--color-primary-bg);
+  }
+
+  .closeButton:active {
+    background: var(--color-bg-tertiary);
+    transform: scale(0.95);
+  }
+
+  .content {
+    -webkit-overflow-scrolling: touch;
+    overscroll-behavior: contain;
+  }
+
+  .nav {
+    -webkit-overflow-scrolling: touch;
+  }
+}
+
+// セーフエリア対応
+@supports (padding: env(safe-area-inset-bottom)) {
+  @media (max-width: 480px) {
+    .content {
+      padding-bottom: calc(14px + env(safe-area-inset-bottom));
+    }
   }
 }
 

--- a/src/components/Map/Map.module.scss
+++ b/src/components/Map/Map.module.scss
@@ -426,3 +426,374 @@
   color: #9ca3af;
   line-height: 1.4;
 }
+
+// =============================================================================
+// モバイル対応スタイル
+// =============================================================================
+
+// タブレット (768px以下)
+@media (max-width: 768px) {
+  .mapControls {
+    top: 60px;
+    right: 8px;
+    gap: 4px;
+  }
+
+  .toggleButton {
+    width: 40px;
+    height: 40px;
+    font-size: 13px;
+  }
+
+  .waypointMarker {
+    width: 32px;
+    height: 32px;
+    font-size: 13px;
+
+    &.gridMarker {
+      width: 26px;
+      height: 26px;
+      font-size: 11px;
+    }
+  }
+
+  .stylePicker {
+    right: 48px;
+    min-width: 140px;
+  }
+
+  .styleOption {
+    padding: 10px 14px;
+    font-size: 14px;
+    min-height: 44px;
+  }
+
+  .selectionInfo {
+    padding: 8px 16px;
+    font-size: 12px;
+    max-width: 90vw;
+  }
+
+  .instructions {
+    bottom: 20px;
+    padding: 10px 16px;
+    font-size: 12px;
+    flex-wrap: wrap;
+    justify-content: center;
+    gap: 8px 16px;
+    max-width: 90vw;
+    border-radius: 12px;
+    text-align: center;
+    white-space: normal;
+  }
+
+  .apiOverlay {
+    right: 56px;
+    max-width: 260px;
+  }
+}
+
+// 大型スマートフォン (600px以下)
+@media (max-width: 600px) {
+  .mapControls {
+    top: 50px;
+    right: 6px;
+    gap: 3px;
+  }
+
+  .toggleButton {
+    width: 36px;
+    height: 36px;
+    font-size: 12px;
+    border-radius: 6px;
+  }
+
+  .waypointMarker {
+    width: 28px;
+    height: 28px;
+    font-size: 11px;
+
+    &.gridMarker {
+      width: 22px;
+      height: 22px;
+      font-size: 9px;
+    }
+  }
+
+  .stylePicker {
+    right: auto;
+    left: 50%;
+    top: auto;
+    bottom: 60px;
+    transform: translateX(-50%);
+    flex-direction: row;
+    flex-wrap: wrap;
+    justify-content: center;
+    min-width: auto;
+    max-width: 90vw;
+    padding: 6px;
+  }
+
+  .styleOption {
+    padding: 8px 12px;
+    font-size: 12px;
+    min-height: 40px;
+  }
+
+  .selectionInfo {
+    top: 50px;
+    padding: 6px 12px;
+    font-size: 11px;
+  }
+
+  .instructions {
+    bottom: 16px;
+    padding: 8px 12px;
+    font-size: 10px;
+    gap: 6px 12px;
+    border-radius: 10px;
+  }
+
+  .apiOverlay {
+    right: 44px;
+    max-width: 220px;
+    top: 50px;
+  }
+
+  .apiOverlayHeader {
+    padding: 8px 10px;
+    font-size: 12px;
+  }
+
+  .apiInfoRow {
+    padding: 4px 0;
+  }
+
+  .apiInfoLabel {
+    font-size: 10px;
+  }
+
+  .apiInfoValue {
+    font-size: 11px;
+    max-width: 120px;
+  }
+}
+
+// 標準スマートフォン (480px以下)
+@media (max-width: 480px) {
+  .mapControls {
+    top: 8px;
+    right: 4px;
+    gap: 2px;
+  }
+
+  .toggleButton {
+    width: 32px;
+    height: 32px;
+    font-size: 10px;
+    border-radius: 5px;
+  }
+
+  .waypointMarker {
+    width: 24px;
+    height: 24px;
+    font-size: 10px;
+    border-width: 2px;
+
+    &.gridMarker {
+      width: 18px;
+      height: 18px;
+      font-size: 8px;
+    }
+
+    &.highlighted {
+      transform: scale(1.2);
+    }
+  }
+
+  @keyframes highlightPulse {
+    0%, 100% {
+      box-shadow: 0 0 0 4px rgba(0, 191, 255, 0.6), 0 0 15px rgba(0, 191, 255, 0.8);
+      transform: scale(1.2);
+    }
+    50% {
+      box-shadow: 0 0 0 8px rgba(0, 191, 255, 0.3), 0 0 25px rgba(0, 191, 255, 0.5);
+      transform: scale(1.3);
+    }
+  }
+
+  .stylePicker {
+    bottom: 50px;
+    padding: 4px;
+    border-radius: 6px;
+  }
+
+  .styleOption {
+    padding: 6px 10px;
+    font-size: 11px;
+    min-height: 36px;
+    border-radius: 4px;
+  }
+
+  .styleIcon {
+    font-size: 14px;
+  }
+
+  .selectionInfo {
+    top: 40px;
+    padding: 5px 10px;
+    font-size: 10px;
+    border-radius: 6px;
+  }
+
+  .instructions {
+    display: none; // モバイルでは非表示
+  }
+
+  .apiOverlay {
+    right: 36px;
+    max-width: 180px;
+    top: 8px;
+    font-size: 11px;
+  }
+
+  .apiOverlayHeader {
+    padding: 6px 8px;
+    font-size: 11px;
+  }
+
+  .apiOverlayContent {
+    padding: 8px;
+  }
+
+  .apiInfoLabel {
+    font-size: 9px;
+  }
+
+  .apiInfoValue {
+    font-size: 10px;
+    max-width: 90px;
+  }
+
+  .apiErrorMessage {
+    font-size: 11px;
+  }
+
+  .apiErrorHint {
+    font-size: 9px;
+  }
+}
+
+// 小型スマートフォン (375px以下)
+@media (max-width: 375px) {
+  .mapControls {
+    gap: 1px;
+  }
+
+  .toggleButton {
+    width: 28px;
+    height: 28px;
+    font-size: 9px;
+  }
+
+  .waypointMarker {
+    width: 20px;
+    height: 20px;
+    font-size: 8px;
+
+    &.gridMarker {
+      width: 16px;
+      height: 16px;
+      font-size: 7px;
+    }
+  }
+
+  .styleOption {
+    padding: 5px 8px;
+    font-size: 10px;
+  }
+
+  .apiOverlay {
+    max-width: 160px;
+    right: 32px;
+  }
+}
+
+// 超小型スマートフォン (320px以下)
+@media (max-width: 320px) {
+  .toggleButton {
+    width: 26px;
+    height: 26px;
+    font-size: 8px;
+  }
+
+  .waypointMarker {
+    width: 18px;
+    height: 18px;
+    font-size: 7px;
+
+    &.gridMarker {
+      width: 14px;
+      height: 14px;
+      font-size: 6px;
+    }
+  }
+
+  .apiOverlay {
+    display: none; // 極小画面では非表示
+  }
+}
+
+// タッチデバイス最適化
+@media (hover: none) and (pointer: coarse) {
+  .toggleButton {
+    min-width: 44px;
+    min-height: 44px;
+  }
+
+  .toggleButton:active {
+    transform: scale(0.95);
+    opacity: 0.8;
+  }
+
+  .styleOption:active {
+    background: var(--color-primary-bg);
+    transform: scale(0.98);
+  }
+
+  .waypointMarker {
+    // タッチデバイスでマーカーを少し大きく
+    min-width: 32px;
+    min-height: 32px;
+
+    &.gridMarker {
+      min-width: 24px;
+      min-height: 24px;
+    }
+  }
+
+  // ホバー効果を無効化
+  .waypointMarker:hover {
+    transform: none;
+  }
+
+  .waypointMarker:active {
+    transform: scale(0.9);
+  }
+
+  // スタイルピッカーを閉じやすく
+  .stylePicker {
+    padding: 8px;
+  }
+
+  .styleOption {
+    min-height: 48px;
+  }
+}
+
+// セーフエリア対応
+@supports (padding: env(safe-area-inset-right)) {
+  .mapControls {
+    right: calc(8px + env(safe-area-inset-right));
+  }
+}

--- a/src/components/PolygonList/PolygonList.module.scss
+++ b/src/components/PolygonList/PolygonList.module.scss
@@ -188,3 +188,251 @@
   font-size: 12px;
   color: var(--color-text-secondary);
 }
+
+// =============================================================================
+// モバイル対応スタイル
+// =============================================================================
+
+// タブレット (768px以下)
+@media (max-width: 768px) {
+  .header {
+    padding: 10px 14px;
+  }
+
+  .count {
+    font-size: 12px;
+  }
+
+  .generateAllButton {
+    padding: 8px 14px;
+    font-size: 11px;
+    min-height: 36px;
+  }
+
+  .item {
+    padding: 10px 14px;
+  }
+
+  .actionButton {
+    width: 36px;
+    height: 36px;
+  }
+
+  .name {
+    font-size: 13px;
+  }
+
+  .stats {
+    gap: 6px 12px;
+    font-size: 11px;
+  }
+}
+
+// 大型スマートフォン (600px以下)
+@media (max-width: 600px) {
+  .header {
+    padding: 10px 12px;
+    flex-wrap: wrap;
+    gap: 8px;
+  }
+
+  .count {
+    font-size: 11px;
+  }
+
+  .generateAllButton {
+    padding: 6px 10px;
+    font-size: 10px;
+  }
+
+  .item {
+    padding: 10px 12px;
+  }
+
+  .topRow {
+    margin-bottom: 6px;
+  }
+
+  .colorIndicator {
+    width: 10px;
+    height: 10px;
+  }
+
+  .actions {
+    gap: 3px;
+  }
+
+  .actionButton {
+    width: 32px;
+    height: 32px;
+    font-size: 12px;
+  }
+
+  .content {
+    gap: 4px;
+  }
+
+  .index {
+    font-size: 11px;
+  }
+
+  .name {
+    font-size: 12px;
+  }
+
+  .nameInput {
+    font-size: 12px;
+    padding: 3px 6px;
+  }
+
+  .stats {
+    gap: 4px 10px;
+    font-size: 10px;
+  }
+}
+
+// 標準スマートフォン (480px以下)
+@media (max-width: 480px) {
+  .emptyState {
+    padding: 16px;
+
+    p {
+      font-size: 13px;
+    }
+
+    .hint {
+      font-size: 11px;
+    }
+  }
+
+  .header {
+    padding: 8px 10px;
+  }
+
+  .count {
+    font-size: 11px;
+  }
+
+  .generateAllButton {
+    padding: 6px 8px;
+    font-size: 10px;
+    min-height: 32px;
+  }
+
+  .item {
+    padding: 8px 10px;
+
+    &.selected {
+      padding-left: 7px;
+    }
+  }
+
+  .topRow {
+    margin-bottom: 5px;
+  }
+
+  .colorIndicator {
+    width: 8px;
+    height: 8px;
+  }
+
+  .actionButton {
+    width: 28px;
+    height: 28px;
+    font-size: 11px;
+    border-radius: 3px;
+  }
+
+  .index {
+    font-size: 10px;
+  }
+
+  .name {
+    font-size: 11px;
+    line-height: 1.3;
+  }
+
+  .nameInput {
+    font-size: 11px;
+    padding: 2px 5px;
+  }
+
+  .stats {
+    gap: 4px 8px;
+    font-size: 9px;
+  }
+}
+
+// 小型スマートフォン (375px以下)
+@media (max-width: 375px) {
+  .header {
+    padding: 6px 8px;
+  }
+
+  .generateAllButton {
+    font-size: 9px;
+    padding: 5px 6px;
+  }
+
+  .item {
+    padding: 6px 8px;
+  }
+
+  .actionButton {
+    width: 26px;
+    height: 26px;
+  }
+
+  .name {
+    font-size: 10px;
+  }
+
+  .stats {
+    font-size: 8px;
+    gap: 3px 6px;
+  }
+}
+
+// 超小型スマートフォン (320px以下)
+@media (max-width: 320px) {
+  .actions {
+    gap: 2px;
+  }
+
+  .actionButton {
+    width: 24px;
+    height: 24px;
+    font-size: 10px;
+  }
+
+  .stats {
+    font-size: 8px;
+  }
+}
+
+// タッチデバイス最適化
+@media (hover: none) and (pointer: coarse) {
+  .item:active {
+    background: var(--color-primary-bg);
+  }
+
+  .actionButton:active {
+    transform: scale(0.9);
+    opacity: 0.7;
+  }
+
+  .generateAllButton:active {
+    transform: scale(0.98);
+    opacity: 0.8;
+  }
+
+  .list {
+    -webkit-overflow-scrolling: touch;
+    overscroll-behavior: contain;
+  }
+
+  // タッチデバイスでは常にアクションボタンを表示
+  .actions {
+    opacity: 1;
+  }
+}

--- a/src/components/SearchForm/SearchForm.module.scss
+++ b/src/components/SearchForm/SearchForm.module.scss
@@ -358,3 +358,305 @@
     transform: translateY(0);
   }
 }
+
+// =============================================================================
+// モバイル対応スタイル
+// =============================================================================
+
+// タブレット (768px以下)
+@media (max-width: 768px) {
+  .input {
+    padding: 12px 36px 12px 12px;
+    font-size: 16px; // ズーム防止
+    min-height: 44px;
+  }
+
+  .clearButton {
+    width: 32px;
+    height: 32px;
+  }
+
+  .suggestionItem {
+    padding: 12px;
+    min-height: 48px;
+  }
+
+  .suggestionName {
+    font-size: 14px;
+  }
+
+  .suggestionAddress {
+    font-size: 13px;
+  }
+
+  .panelHeader {
+    padding: 14px 12px;
+    min-height: 48px;
+  }
+
+  .shapeButton {
+    padding: 10px 12px;
+    min-height: 44px;
+  }
+
+  .sizeButton {
+    padding: 8px 10px;
+    min-height: 36px;
+  }
+
+  .generateButton {
+    padding: 14px;
+    min-height: 48px;
+  }
+}
+
+// 大型スマートフォン (600px以下)
+@media (max-width: 600px) {
+  .input {
+    padding: 10px 32px 10px 10px;
+  }
+
+  .suggestions {
+    max-height: 250px;
+  }
+
+  .suggestionItem {
+    padding: 10px;
+  }
+
+  .suggestionName {
+    font-size: 13px;
+  }
+
+  .suggestionAddress {
+    font-size: 12px;
+  }
+
+  .panelHeader {
+    padding: 12px 10px;
+  }
+
+  .selectedLocation {
+    gap: 6px;
+  }
+
+  .locationName {
+    font-size: 13px;
+  }
+
+  .panelContent {
+    padding: 0 10px 10px;
+  }
+
+  .shapeSelector label,
+  .sizeSelector label,
+  .waypointSelector label {
+    font-size: 11px;
+  }
+
+  .shapeButton {
+    padding: 8px 10px;
+    font-size: 11px;
+  }
+
+  .sizeButton {
+    padding: 6px 8px;
+    font-size: 10px;
+  }
+}
+
+// 標準スマートフォン (480px以下)
+@media (max-width: 480px) {
+  .input {
+    padding: 10px 30px 10px 10px;
+    font-size: 16px; // ズーム防止
+    border-radius: 8px;
+  }
+
+  .clearButton {
+    width: 28px;
+    height: 28px;
+    right: 6px;
+  }
+
+  .suggestions {
+    max-height: 200px;
+    border-radius: 8px;
+  }
+
+  .suggestionItem {
+    padding: 10px 8px;
+  }
+
+  .generatePanel {
+    margin-top: 10px;
+    border-radius: 6px;
+  }
+
+  .panelHeader {
+    padding: 10px 8px;
+  }
+
+  .locationIcon {
+    width: 16px;
+    height: 16px;
+  }
+
+  .locationName {
+    font-size: 12px;
+  }
+
+  .panelContent {
+    padding: 0 8px 8px;
+  }
+
+  .optionsRow {
+    margin-bottom: 10px;
+  }
+
+  .shapeButtons {
+    gap: 6px;
+  }
+
+  .shapeButton {
+    padding: 8px;
+    font-size: 10px;
+    gap: 4px;
+  }
+
+  .sizeButtons {
+    gap: 4px;
+  }
+
+  .sizeButton {
+    padding: 6px;
+    font-size: 9px;
+    min-height: 32px;
+  }
+
+  .sizeSelector,
+  .waypointSelector {
+    margin-bottom: 10px;
+  }
+
+  .sliderWrapper {
+    margin-top: 8px;
+    gap: 8px;
+  }
+
+  .slider {
+    &::-webkit-slider-thumb {
+      width: 20px;
+      height: 20px;
+    }
+
+    &::-moz-range-thumb {
+      width: 20px;
+      height: 20px;
+    }
+  }
+
+  .sliderValue {
+    font-size: 11px;
+    min-width: 45px;
+  }
+
+  .generateButton {
+    padding: 12px;
+    font-size: 13px;
+    border-radius: 8px;
+  }
+}
+
+// 小型スマートフォン (375px以下)
+@media (max-width: 375px) {
+  .input {
+    padding: 8px 28px 8px 8px;
+    font-size: 15px;
+  }
+
+  .suggestionItem {
+    padding: 8px 6px;
+  }
+
+  .suggestionName {
+    font-size: 12px;
+  }
+
+  .suggestionAddress {
+    font-size: 11px;
+  }
+
+  .shapeButton {
+    padding: 6px;
+    font-size: 9px;
+  }
+
+  .sizeButton {
+    font-size: 8px;
+    padding: 5px;
+  }
+
+  .generateButton {
+    padding: 10px;
+    font-size: 12px;
+  }
+}
+
+// 超小型スマートフォン (320px以下)
+@media (max-width: 320px) {
+  .shapeButtons {
+    flex-wrap: wrap;
+  }
+
+  .shapeButton {
+    flex: 1 1 45%;
+  }
+
+  .sizeButton {
+    font-size: 8px;
+    padding: 4px;
+  }
+}
+
+// タッチデバイス最適化
+@media (hover: none) and (pointer: coarse) {
+  .input:focus {
+    // タッチデバイスではフォーカス時のスタイルを調整
+    box-shadow: 0 0 0 2px var(--color-primary-bg);
+  }
+
+  .clearButton:active {
+    background: var(--color-bg-tertiary);
+    transform: scale(0.9);
+  }
+
+  .suggestionItem:active {
+    background: var(--color-primary-bg);
+  }
+
+  .shapeButton:active,
+  .sizeButton:active,
+  .generateButton:active {
+    transform: scale(0.98);
+    opacity: 0.8;
+  }
+
+  .slider {
+    height: 6px;
+
+    &::-webkit-slider-thumb {
+      width: 24px;
+      height: 24px;
+    }
+
+    &::-moz-range-thumb {
+      width: 24px;
+      height: 24px;
+    }
+  }
+
+  .suggestions {
+    -webkit-overflow-scrolling: touch;
+  }
+}

--- a/src/components/WaypointList/WaypointList.module.scss
+++ b/src/components/WaypointList/WaypointList.module.scss
@@ -367,3 +367,383 @@
     box-shadow: 0 0 0 2px var(--color-primary-bg);
   }
 }
+
+// =============================================================================
+// モバイル対応スタイル
+// =============================================================================
+
+// タブレット (768px以下)
+@media (max-width: 768px) {
+  .header {
+    padding: 10px 14px;
+  }
+
+  .count {
+    font-size: 12px;
+  }
+
+  .iconButton,
+  .clearButton {
+    width: 36px;
+    height: 36px;
+  }
+
+  .settings {
+    padding: 10px 14px;
+  }
+
+  .slider {
+    height: 6px;
+
+    &::-webkit-slider-thumb {
+      width: 18px;
+      height: 18px;
+    }
+  }
+
+  .regenerateButton {
+    padding: 10px;
+    min-height: 40px;
+  }
+
+  .groupHeader {
+    padding: 8px 14px;
+  }
+
+  .item {
+    padding: 8px 14px;
+    gap: 10px;
+  }
+
+  .marker {
+    width: 28px;
+    height: 28px;
+    font-size: 12px;
+  }
+
+  .deleteButton,
+  .editButton {
+    width: 28px;
+    height: 28px;
+  }
+}
+
+// 大型スマートフォン (600px以下)
+@media (max-width: 600px) {
+  .header {
+    padding: 8px 12px;
+  }
+
+  .count {
+    font-size: 11px;
+  }
+
+  .headerActions {
+    gap: 4px;
+  }
+
+  .iconButton,
+  .clearButton {
+    width: 32px;
+    height: 32px;
+  }
+
+  .progress {
+    padding: 6px 12px;
+    font-size: 10px;
+  }
+
+  .settings {
+    padding: 8px 12px;
+  }
+
+  .settingRow {
+    gap: 10px;
+
+    label {
+      font-size: 11px;
+    }
+  }
+
+  .sliderValue {
+    font-size: 11px;
+  }
+
+  .regenerateButton {
+    padding: 8px;
+    font-size: 11px;
+  }
+
+  .groupHeader {
+    padding: 8px 12px;
+    font-size: 12px;
+  }
+
+  .groupCount {
+    font-size: 10px;
+  }
+
+  .item {
+    padding: 8px 12px;
+    gap: 8px;
+  }
+
+  .marker {
+    width: 24px;
+    height: 24px;
+    font-size: 10px;
+  }
+
+  .coords {
+    font-size: 11px;
+  }
+
+  .type {
+    font-size: 10px;
+    padding: 2px 6px;
+  }
+
+  .deleteButton,
+  .editButton {
+    width: 24px;
+    height: 24px;
+  }
+}
+
+// 標準スマートフォン (480px以下)
+@media (max-width: 480px) {
+  .emptyState {
+    padding: 14px;
+
+    p {
+      font-size: 12px;
+    }
+
+    .hint {
+      font-size: 10px;
+    }
+  }
+
+  .header {
+    padding: 6px 10px;
+  }
+
+  .count {
+    font-size: 10px;
+  }
+
+  .iconButton,
+  .clearButton {
+    width: 28px;
+    height: 28px;
+  }
+
+  .progress {
+    padding: 5px 10px;
+    font-size: 9px;
+  }
+
+  .settings {
+    padding: 8px 10px;
+  }
+
+  .settingRow {
+    flex-wrap: wrap;
+    gap: 6px;
+
+    label {
+      font-size: 10px;
+      flex: 1 1 100%;
+    }
+  }
+
+  .slider {
+    height: 8px;
+
+    &::-webkit-slider-thumb {
+      width: 22px;
+      height: 22px;
+    }
+
+    &::-moz-range-thumb {
+      width: 22px;
+      height: 22px;
+    }
+  }
+
+  .sliderValue {
+    font-size: 10px;
+    min-width: 35px;
+  }
+
+  .regenerateButton {
+    padding: 8px;
+    font-size: 10px;
+    margin-top: 8px;
+    gap: 4px;
+  }
+
+  .groupHeader {
+    padding: 6px 10px;
+    font-size: 11px;
+  }
+
+  .groupName {
+    font-size: 11px;
+  }
+
+  .groupCount {
+    font-size: 9px;
+    padding: 1px 6px;
+  }
+
+  .item {
+    padding: 6px 10px;
+    gap: 6px;
+  }
+
+  .marker {
+    width: 22px;
+    height: 22px;
+    font-size: 9px;
+  }
+
+  .coords {
+    font-size: 10px;
+    gap: 1px;
+  }
+
+  .type {
+    font-size: 9px;
+    padding: 1px 5px;
+  }
+
+  .deleteButton,
+  .editButton {
+    width: 22px;
+    height: 22px;
+  }
+
+  .coordInput {
+    font-size: 11px;
+    padding: 3px 5px;
+  }
+
+  .indexInput {
+    width: 28px;
+    height: 22px;
+    font-size: 9px;
+  }
+}
+
+// 小型スマートフォン (375px以下)
+@media (max-width: 375px) {
+  .header {
+    padding: 5px 8px;
+  }
+
+  .iconButton,
+  .clearButton {
+    width: 26px;
+    height: 26px;
+  }
+
+  .settings {
+    padding: 6px 8px;
+  }
+
+  .groupHeader {
+    padding: 5px 8px;
+  }
+
+  .item {
+    padding: 5px 8px;
+  }
+
+  .marker {
+    width: 20px;
+    height: 20px;
+    font-size: 8px;
+  }
+
+  .coords {
+    font-size: 9px;
+  }
+
+  .type {
+    font-size: 8px;
+  }
+
+  .deleteButton,
+  .editButton {
+    width: 20px;
+    height: 20px;
+  }
+}
+
+// 超小型スマートフォン (320px以下)
+@media (max-width: 320px) {
+  .headerActions {
+    gap: 2px;
+  }
+
+  .iconButton,
+  .clearButton {
+    width: 24px;
+    height: 24px;
+  }
+
+  .marker {
+    width: 18px;
+    height: 18px;
+    font-size: 7px;
+  }
+
+  .coords {
+    font-size: 8px;
+  }
+
+  .type {
+    display: none;
+  }
+}
+
+// タッチデバイス最適化
+@media (hover: none) and (pointer: coarse) {
+  .item:active {
+    background: var(--color-primary-bg);
+  }
+
+  .iconButton:active,
+  .clearButton:active,
+  .deleteButton:active,
+  .editButton:active {
+    transform: scale(0.9);
+    opacity: 0.7;
+  }
+
+  .regenerateButton:active {
+    transform: scale(0.98);
+    opacity: 0.8;
+  }
+
+  .groups {
+    -webkit-overflow-scrolling: touch;
+    overscroll-behavior: contain;
+  }
+
+  // スライダーをタッチしやすく
+  .slider {
+    height: 8px;
+
+    &::-webkit-slider-thumb {
+      width: 28px;
+      height: 28px;
+    }
+
+    &::-moz-range-thumb {
+      width: 28px;
+      height: 28px;
+    }
+  }
+}

--- a/src/styles/theme.scss
+++ b/src/styles/theme.scss
@@ -3,6 +3,64 @@
  * CSS変数を使用してダーク/ライトモードを切り替え
  */
 
+// =============================================================================
+// レスポンシブ ブレークポイント
+// =============================================================================
+$breakpoint-xs: 320px;   // 小型スマートフォン
+$breakpoint-sm: 375px;   // 標準スマートフォン (iPhone SE)
+$breakpoint-md: 480px;   // 大型スマートフォン
+$breakpoint-lg: 600px;   // 小型タブレット
+$breakpoint-tablet: 768px;   // タブレット
+$breakpoint-desktop: 1024px; // デスクトップ
+
+// Mixins for responsive design
+@mixin mobile-xs {
+  @media (max-width: #{$breakpoint-xs}) {
+    @content;
+  }
+}
+
+@mixin mobile-sm {
+  @media (max-width: #{$breakpoint-sm}) {
+    @content;
+  }
+}
+
+@mixin mobile-md {
+  @media (max-width: #{$breakpoint-md}) {
+    @content;
+  }
+}
+
+@mixin mobile-lg {
+  @media (max-width: #{$breakpoint-lg}) {
+    @content;
+  }
+}
+
+@mixin tablet {
+  @media (max-width: #{$breakpoint-tablet}) {
+    @content;
+  }
+}
+
+@mixin desktop {
+  @media (max-width: #{$breakpoint-desktop}) {
+    @content;
+  }
+}
+
+// タッチデバイス用
+@mixin touch-device {
+  @media (hover: none) and (pointer: coarse) {
+    @content;
+  }
+}
+
+// =============================================================================
+// モバイル用 CSS変数
+// =============================================================================
+
 // ライトモード（デフォルト）
 :root,
 [data-theme="light"] {
@@ -139,4 +197,67 @@
 // トランジション（テーマ切り替え時のアニメーション）
 * {
   transition: background-color 0.2s ease, border-color 0.2s ease, color 0.2s ease;
+}
+
+// =============================================================================
+// モバイル用グローバルスタイル
+// =============================================================================
+
+// タッチターゲットの最小サイズ（44px推奨）
+$touch-target-min: 44px;
+$touch-target-sm: 36px;
+
+// モバイル用フォントサイズ
+$font-size-mobile-base: 14px;
+$font-size-mobile-sm: 12px;
+$font-size-mobile-xs: 11px;
+
+// モバイル用スペーシング
+$spacing-mobile-xs: 4px;
+$spacing-mobile-sm: 8px;
+$spacing-mobile-md: 12px;
+$spacing-mobile-lg: 16px;
+
+// タッチフレンドリーなボタンスタイル
+@mixin touch-friendly-button {
+  min-height: $touch-target-min;
+  min-width: $touch-target-min;
+
+  @include touch-device {
+    // タッチデバイスではタップ領域を広げる
+    position: relative;
+
+    &::before {
+      content: '';
+      position: absolute;
+      top: -8px;
+      left: -8px;
+      right: -8px;
+      bottom: -8px;
+    }
+  }
+}
+
+// スクロール可能なコンテナ（モバイル最適化）
+@mixin mobile-scroll-container {
+  overflow-y: auto;
+  -webkit-overflow-scrolling: touch;
+  overscroll-behavior: contain;
+
+  // スクロールバーを細くする（モバイル）
+  &::-webkit-scrollbar {
+    width: 4px;
+  }
+
+  &::-webkit-scrollbar-thumb {
+    background: var(--color-border);
+    border-radius: 2px;
+  }
+}
+
+// セーフエリア対応
+@mixin safe-area-inset {
+  padding-left: env(safe-area-inset-left);
+  padding-right: env(safe-area-inset-right);
+  padding-bottom: env(safe-area-inset-bottom);
 }


### PR DESCRIPTION
- 6段階のブレークポイント追加（320px, 375px, 480px, 600px, 768px, 1024px）
- 共通SCSSミックスインを theme.scss に追加
- すべての主要コンポーネントにレスポンシブスタイル追加
- タッチターゲット最小44px確保
- iOSズーム防止（入力フィールド16px以上）
- セーフエリア対応（ノッチ付きデバイス）
- タッチデバイス最適化（:active状態、スクロール最適化）
- ランドスケープモード対応

対応コンポーネント:
- App.scss: メインレイアウト
- FlightAssistant: AIチャットウィジェット
- ExportPanel: エクスポートモーダル
- HelpModal: ヘルプモーダル
- SearchForm: 検索フォーム
- PolygonList: ポリゴンリスト
- WaypointList: ウェイポイントリスト
- Map: 地図コントロール
- FileImport: ファイルインポート
- GridSettingsDialog: グリッド設定