### PR TITLE
fix: モバイルで入力フィールドの自動ズームを防止

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="UTF-8" />
     <link rel="icon" href="data:image/svg+xml,<svg xmlns=%22http://www.w3.org/2000/svg%22 viewBox=%220 0 100 100%22><text y=%22.9em%22 font-size=%2290%22>🚁</text></svg>" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no" />
     <title>Drone Waypoint - ドローン点検Waypoint管理</title>
   </head>
   <body>

--- a/src/App.scss
+++ b/src/App.scss
@@ -2,6 +2,13 @@
   box-sizing: border-box;
 }
 
+// モバイルでの自動ズームを防止するため、全入力フィールドのfont-sizeを16px以上に設定
+input,
+textarea,
+select {
+  font-size: 16px;
+}
+
 body {
   margin: 0;
   font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, sans-serif;

--- a/src/components/ApiSettings/ApiSettings.scss
+++ b/src/components/ApiSettings/ApiSettings.scss
@@ -194,7 +194,7 @@
     border: 1px solid var(--color-border);
     border-radius: 8px;
     color: var(--color-text);
-    font-size: 13px;
+    font-size: 16px; // モバイルでの自動ズームを防止
     transition: all 0.15s;
 
     &::placeholder {
@@ -318,7 +318,7 @@
       border: 1px solid var(--color-border);
       border-radius: 6px;
       color: var(--color-text);
-      font-size: 12px;
+      font-size: 16px; // モバイルでの自動ズームを防止
 
       &::placeholder {
         color: var(--color-text-tertiary);

--- a/src/components/SearchForm/SearchForm.module.scss
+++ b/src/components/SearchForm/SearchForm.module.scss
@@ -18,6 +18,7 @@
     border: 1px solid var(--color-border);
     background: var(--color-bg-secondary);
     color: inherit;
+    font-size: 16px; // モバイルでの自動ズームを防止
   }
 }
 


### PR DESCRIPTION
- viewportにmaximum-scale=1, user-scalable=noを追加
- 全input/textarea/selectのfont-sizeを16px以上に設定
- iOS Safariでフォーカス時の自動ズームを無効化