### PR TITLE
fix: Oキーのショートカット競合を解消

### DIFF
--- a/src/components/Map/Map.jsx
+++ b/src/components/Map/Map.jsx
@@ -579,10 +579,8 @@ const Map = ({
           e.preventDefault()
           toggleLayer('showRainCloud')
           break
-        case 'o': // Wind toggle
-          e.preventDefault()
-          toggleLayer('showWind')
-          break
+        // 'o' key is reserved for Weather Forecast panel (MainLayout.jsx)
+        // Wind toggle will be re-enabled when the feature is implemented
         case 't': // Radio zones (LTE) toggle
           e.preventDefault()
           toggleLayer('showRadioZones')


### PR DESCRIPTION
## Summary
- Map.jsxからOキー（風向・風量トグル）を削除
- Oキーは天気予報パネル専用に統一

## 理由
風向・風量機能は未実装（ボタンもdisabled状態）のため、ショートカットを一時削除

Closes #21