### PR TITLE
feat: ポリゴン衝突時の重複エリア可視化

### DIFF
--- a/src/lib/utils/collision.ts
+++ b/src/lib/utils/collision.ts
@@ -44,6 +44,7 @@ export interface PolygonCollisionResult {
   overlapRatio: number
   severity: CollisionSeverity
   message: string
+  intersectionPolygons?: Feature<Polygon | MultiPolygon>[]
 }
 
 // RBush item type for spatial indexing
@@ -344,6 +345,7 @@ export function checkPolygonCollision(
 
   let overlapArea = 0
   const polygonArea = turf.area(polygon)
+  const intersectionPolygons: Feature<Polygon | MultiPolygon>[] = []
 
   let intersects = false
   for (const feature of prohibitedAreas.features) {
@@ -355,10 +357,12 @@ export function checkPolygonCollision(
           intersects = true
           // Fix: turf.intersect takes two geometries/features directly in v6
           const intersection = turf.intersect(polygon, polyFeature)
-          
+
           let areaEstimate = 0
           if (intersection) {
              areaEstimate = turf.area(intersection)
+             // Collect intersection polygon for visualization
+             intersectionPolygons.push(intersection as Feature<Polygon | MultiPolygon>)
           } else {
              // Fallback: if intersection exists but geometry calc fails, assume small overlap
              console.warn('Intersection detected but geometry calculation failed', {
@@ -384,7 +388,8 @@ export function checkPolygonCollision(
       overlapArea,
       overlapRatio,
       severity: overlapRatio > 0.2 ? 'DANGER' : 'WARNING',
-      message: `ポリゴンが禁止エリアと${Math.round(overlapRatio * 100)}%重複しています`
+      message: `ポリゴンが禁止エリアと${Math.round(overlapRatio * 100)}%重複しています`,
+      intersectionPolygons
     }
   }
 


### PR DESCRIPTION
## Summary
- ポリゴンが禁止区域と重複した場合、重複エリアを視覚的に表示
- 赤色の半透明塗りつぶしと破線アウトラインで重複エリアをハイライト
- `collision.ts` に `intersectionPolygons` を追加
- `riskService.js` に `checkAllPolygonsCollision()` 関数を追加

## Test plan
- [x] `npm run build` が成功
- [x] `npm test` が全て通過（55 tests）
- [ ] 禁止区域内にポリゴンを描画し、重複エリアが赤く表示されることを確認

Closes #24

🤖 Generated with [Claude Code](https://claude.com/claude-code)