### PR TITLE
feat: Basic認証を追加 (Issue #19)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -19,3 +19,9 @@ VITE_OPENAI_API_KEY=your_openai_api_key_here
 # VITE_MAPTILER_API_KEY=your_maptiler_api_key_here
 
 # Note: OpenStreetMap tiles and Nominatim geocoding are used by default (no API key required)
+
+# ===== Basic認証 (Vercel) =====
+# Vercelデプロイ時のBasic認証設定
+# BASIC_AUTH_ENABLED=true
+# BASIC_AUTH_USER=admin
+# BASIC_AUTH_PASSWORD=your_password_here

--- a/middleware.ts
+++ b/middleware.ts
@@ -1,0 +1,44 @@
+/**
+ * Vercel Edge Middleware - Basic認証
+ * 環境変数でユーザー名とパスワードを設定
+ *
+ * 必要な環境変数:
+ * - BASIC_AUTH_USER: ユーザー名
+ * - BASIC_AUTH_PASSWORD: パスワード
+ * - BASIC_AUTH_ENABLED: "true" で認証を有効化
+ */
+
+export const config = {
+  matcher: ['/((?!api|_next/static|_next/image|favicon.ico).*)']
+}
+
+export default function middleware(request: Request) {
+  const authEnabled = process.env.BASIC_AUTH_ENABLED === 'true'
+
+  if (!authEnabled) {
+    return
+  }
+
+  const basicAuth = request.headers.get('authorization')
+  const expectedUser = process.env.BASIC_AUTH_USER || 'admin'
+  const expectedPassword = process.env.BASIC_AUTH_PASSWORD || 'password'
+
+  if (basicAuth) {
+    const authValue = basicAuth.split(' ')[1]
+    try {
+      const [user, password] = atob(authValue).split(':')
+      if (user === expectedUser && password === expectedPassword) {
+        return
+      }
+    } catch {
+      // Invalid base64
+    }
+  }
+
+  return new Response('認証が必要です', {
+    status: 401,
+    headers: {
+      'WWW-Authenticate': 'Basic realm="Secure Area"'
+    }
+  })
+}


### PR DESCRIPTION
## Summary
- Vercel Edge MiddlewareでBasic認証を実装
- 環境変数で認証の有効/無効を切り替え可能
- .env.exampleに設定例を追記

## 設定方法
Vercelの環境変数に以下を設定:
- `BASIC_AUTH_ENABLED`: `true` で有効化
- `BASIC_AUTH_USER`: ユーザー名
- `BASIC_AUTH_PASSWORD`: パスワード

## Test plan
- [ ] Vercelにデプロイして認証ダイアログが表示されることを確認
- [ ] 正しい認証情報でアクセスできることを確認
- [ ] BASIC_AUTH_ENABLED=falseで認証なしでアクセスできることを確認

Closes #19