### PR TITLE
feat: ホバーツールチップ機能とルート最適化のWIP化

### DIFF
--- a/src/App.scss
+++ b/src/App.scss
@@ -351,6 +351,110 @@ body {
   transition: opacity 0.2s ease;
 }
 
+// Map Quick Controls - サイドバー内の地図クイックコントローラー
+.map-quick-controls {
+  border-bottom: 1px solid var(--color-border);
+  background: var(--color-bg-secondary);
+
+  &-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    padding: 8px 16px;
+    cursor: pointer;
+    user-select: none;
+    transition: background-color 0.15s;
+
+    &:hover {
+      background: var(--color-bg-tertiary);
+    }
+  }
+
+  &-title {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    font-size: 12px;
+    font-weight: 600;
+    color: var(--color-text-secondary);
+    text-transform: uppercase;
+    letter-spacing: 0.5px;
+  }
+
+  &-chevron {
+    color: var(--color-text-tertiary);
+    transition: transform 0.2s;
+
+    &.expanded {
+      transform: rotate(180deg);
+    }
+  }
+
+  &-content {
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+    padding: 4px 16px 12px;
+  }
+}
+
+.map-quick-control-item {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 6px 8px;
+  border-radius: 6px;
+  font-size: 12px;
+  color: var(--color-text);
+  cursor: pointer;
+  transition: background-color 0.15s;
+  user-select: none;
+
+  &:hover:not(:has(input:disabled)) {
+    background: var(--color-bg-tertiary);
+  }
+
+  input[type='checkbox'] {
+    width: 14px;
+    height: 14px;
+    margin: 0;
+    cursor: pointer;
+    accent-color: var(--color-primary);
+    flex-shrink: 0;
+
+    &:disabled {
+      cursor: not-allowed;
+      opacity: 0.5;
+    }
+  }
+
+  &:has(input:disabled) {
+    opacity: 0.5;
+    cursor: not-allowed;
+  }
+
+  span {
+    flex: 1;
+  }
+
+  kbd {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    min-width: 18px;
+    height: 18px;
+    padding: 0 4px;
+    font-size: 10px;
+    font-weight: 600;
+    font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+    color: var(--color-text-secondary);
+    background: var(--color-bg);
+    border: 1px solid var(--color-border);
+    border-radius: 3px;
+    line-height: 1;
+  }
+}
+
 .panel-tabs {
   display: flex;
   border-bottom: 1px solid var(--color-border);

--- a/src/App.scss
+++ b/src/App.scss
@@ -407,6 +407,24 @@ body {
     gap: 6px;
     padding: 4px 16px 12px;
   }
+
+  &-desc {
+    margin: 0 0 6px;
+    padding: 8px 10px;
+    font-size: 11px;
+    line-height: 1.5;
+    color: var(--color-text-secondary);
+    background: var(--color-bg);
+    border-radius: 6px;
+    border-left: 2px solid var(--color-primary);
+  }
+
+  &-note {
+    display: inline-block;
+    margin-top: 4px;
+    color: var(--color-warning, #f59e0b);
+    font-weight: 500;
+  }
 }
 
 .map-quick-control-item {

--- a/src/App.scss
+++ b/src/App.scss
@@ -360,13 +360,24 @@ body {
     display: flex;
     align-items: center;
     justify-content: space-between;
+    width: 100%;
     padding: 8px 16px;
+    background: transparent;
+    border: none;
+    color: inherit;
+    font: inherit;
     cursor: pointer;
     user-select: none;
+    text-align: left;
     transition: background-color 0.15s;
 
     &:hover {
       background: var(--color-bg-tertiary);
+    }
+
+    &:focus-visible {
+      outline: 2px solid var(--color-primary);
+      outline-offset: -2px;
     }
   }
 

--- a/src/App.scss
+++ b/src/App.scss
@@ -427,6 +427,10 @@ body {
   }
 
   &-section-label {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 6px;
     font-size: 10px;
     font-weight: 600;
     color: var(--color-text-tertiary);
@@ -434,6 +438,26 @@ body {
     letter-spacing: 0.06em;
     margin-bottom: 2px;
     padding: 0 2px;
+
+    kbd {
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+      min-width: 18px;
+      height: 18px;
+      padding: 0 4px;
+      font-size: 10px;
+      font-weight: 600;
+      font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+      color: var(--color-text-secondary);
+      background: var(--color-bg);
+      border: 1px solid var(--color-border);
+      border-radius: 3px;
+      line-height: 1;
+      text-transform: none;
+      letter-spacing: 0;
+      cursor: help;
+    }
   }
 
   &-desc-note {

--- a/src/App.scss
+++ b/src/App.scss
@@ -1307,3 +1307,102 @@ body {
     }
   }
 }
+
+// ========================================
+// DIDツールチップPopupスタイル（DIDinJapan準拠）
+// maplibregl.Popup はReactの外なのでグローバルCSSで定義
+// ========================================
+.did-tooltip-popup {
+  .maplibregl-popup-content {
+    background: rgba(20, 20, 30, 0.95);
+    backdrop-filter: blur(12px);
+    -webkit-backdrop-filter: blur(12px);
+    border: 1px solid rgba(255, 255, 255, 0.1);
+    border-radius: 8px;
+    padding: 0;
+    box-shadow: 0 8px 32px rgba(0, 0, 0, 0.4), 0 2px 8px rgba(0, 0, 0, 0.3);
+    color: #fff;
+    font-family: 'Inter', 'Noto Sans JP', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+    font-size: 13px;
+  }
+
+  .maplibregl-popup-tip {
+    border-top-color: rgba(20, 20, 30, 0.95);
+  }
+}
+
+.did-popup {
+  padding: 10px 14px;
+}
+
+.did-popup-header {
+  font-size: 15px;
+  font-weight: 700;
+  padding-bottom: 8px;
+  margin-bottom: 6px;
+  border-bottom: 1px solid rgba(255, 255, 255, 0.15);
+  color: #fff;
+}
+
+.did-popup-pref {
+  display: block;
+  font-size: 11px;
+  font-weight: 500;
+  opacity: 0.7;
+  margin-bottom: 2px;
+}
+
+.did-popup-stats {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.did-popup-row {
+  display: flex;
+  justify-content: space-between;
+  gap: 16px;
+  line-height: 1.6;
+
+  span {
+    color: rgba(255, 255, 255, 0.7);
+    white-space: nowrap;
+  }
+
+  strong {
+    color: #fff;
+    font-weight: 600;
+    text-align: right;
+  }
+}
+
+// ライトテーマ対応
+:root[data-theme='light'] {
+  .did-tooltip-popup {
+    .maplibregl-popup-content {
+      background: rgba(255, 255, 255, 0.95);
+      border-color: rgba(0, 0, 0, 0.1);
+      color: #1a1a1a;
+      box-shadow: 0 8px 32px rgba(0, 0, 0, 0.12), 0 2px 8px rgba(0, 0, 0, 0.08);
+    }
+
+    .maplibregl-popup-tip {
+      border-top-color: rgba(255, 255, 255, 0.95);
+    }
+  }
+
+  .did-popup-header {
+    color: #1a1a1a;
+    border-bottom-color: rgba(0, 0, 0, 0.1);
+  }
+
+  .did-popup-row {
+    span {
+      color: rgba(0, 0, 0, 0.6);
+    }
+
+    strong {
+      color: #1a1a1a;
+    }
+  }
+}

--- a/src/App.scss
+++ b/src/App.scss
@@ -404,26 +404,170 @@ body {
   &-content {
     display: flex;
     flex-direction: column;
-    gap: 6px;
-    padding: 4px 16px 12px;
+    padding: 0 16px 10px;
   }
 
-  &-desc {
-    margin: 0 0 6px;
-    padding: 8px 10px;
-    font-size: 11px;
+  &-section {
+    display: flex;
+    flex-direction: column;
+    gap: 3px;
+    padding: 8px 0;
+
+    & + & {
+      border-top: 1px solid var(--color-border);
+    }
+
+    &:first-child {
+      padding-top: 4px;
+    }
+
+    &:last-child {
+      padding-bottom: 2px;
+    }
+  }
+
+  &-section-label {
+    font-size: 10px;
+    font-weight: 600;
+    color: var(--color-text-tertiary);
+    text-transform: uppercase;
+    letter-spacing: 0.06em;
+    margin-bottom: 2px;
+    padding: 0 2px;
+  }
+
+  &-desc-note {
+    margin: 4px 2px 0;
+    font-size: 10.5px;
     line-height: 1.5;
+    color: var(--color-text-tertiary);
+
+    &::before {
+      content: '— ';
+      opacity: 0.6;
+    }
+  }
+
+  &-row {
+    display: flex;
+    gap: 4px;
+    padding: 2px;
+  }
+
+  &-select {
+    flex: 1;
+    min-width: 0;
+    padding: 4px 6px;
+    font-size: 11px;
+    color: var(--color-text);
+    background: var(--color-bg);
+    border: 1px solid var(--color-border);
+    border-radius: 4px;
+    cursor: pointer;
+
+    &:disabled {
+      opacity: 0.5;
+      cursor: not-allowed;
+    }
+
+    &.full-width {
+      width: 100%;
+    }
+  }
+
+  &-style-grid {
+    display: grid;
+    grid-template-columns: repeat(3, 1fr);
+    gap: 4px;
+    padding: 2px;
+  }
+
+  &-style-btn {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 2px;
+    padding: 6px 4px;
+    background: var(--color-bg);
+    border: 1px solid var(--color-border);
+    border-radius: 4px;
+    font-size: 10px;
+    color: var(--color-text-secondary);
+    cursor: pointer;
+    transition: all 0.15s;
+
+    &:hover {
+      border-color: var(--color-primary);
+      color: var(--color-text);
+    }
+
+    &.active {
+      background: var(--color-primary);
+      border-color: var(--color-primary);
+      color: #fff;
+    }
+
+    svg {
+      opacity: 0.8;
+    }
+  }
+}
+
+.map-quick-control-button {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 6px 8px;
+  background: transparent;
+  border: 1px solid var(--color-border);
+  border-radius: 6px;
+  font-size: 12px;
+  color: var(--color-text);
+  cursor: pointer;
+  transition: all 0.15s;
+  text-align: left;
+  width: 100%;
+
+  &:hover {
+    background: var(--color-bg-tertiary);
+    border-color: var(--color-primary);
+  }
+
+  &.active {
+    background: var(--color-primary);
+    border-color: var(--color-primary);
+    color: #fff;
+
+    kbd {
+      background: rgba(255, 255, 255, 0.2);
+      color: #fff;
+      border-color: rgba(255, 255, 255, 0.3);
+    }
+  }
+
+  svg {
+    flex-shrink: 0;
+  }
+
+  span {
+    flex: 1;
+  }
+
+  kbd {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    min-width: 18px;
+    height: 18px;
+    padding: 0 4px;
+    font-size: 10px;
+    font-weight: 600;
+    font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
     color: var(--color-text-secondary);
     background: var(--color-bg);
-    border-radius: 6px;
-    border-left: 2px solid var(--color-primary);
-  }
-
-  &-note {
-    display: inline-block;
-    margin-top: 4px;
-    color: var(--color-warning, #f59e0b);
-    font-weight: 500;
+    border: 1px solid var(--color-border);
+    border-radius: 3px;
+    line-height: 1;
   }
 }
 

--- a/src/components/MainLayout/MainLayout.jsx
+++ b/src/components/MainLayout/MainLayout.jsx
@@ -1,6 +1,6 @@
 import { useState, useEffect, useCallback, useRef, useMemo } from 'react'
 import { ChevronDown, Search, Undo2, Redo2, Map as MapIcon, Layers, Settings, Sun, Moon, Menu, Route, Maximize2, Minimize2, X, Download } from 'lucide-react'
-import { getSetting, isDIDAvoidanceModeEnabled, getWaypointNumberingMode } from '../../services/settingsService'
+import { getSetting, setSetting, isDIDAvoidanceModeEnabled, getWaypointNumberingMode } from '../../services/settingsService'
 import { getDetailedCollisionResults, getDetailedCollisionResultsWithRestrictionSurfaces, checkWaypointsRestrictionSurfaces, checkAllWaypointsDID, checkAllPolygonsCollision } from '../../services/riskService'
 import { preloadDIDDataForCoordinates, isAllDIDCacheReady } from '../../services/didService'
 import MapComponent from '../Map/Map'
@@ -155,28 +155,17 @@ function MainLayout() {
   const [isMapQuickControlsExpanded, setIsMapQuickControlsExpanded] = useState(true)
 
   // Map quick controls state (sidebar に表示、デフォルトOFF)
-  const [showDIDTooltip, setShowDIDTooltip] = useState(() => {
-    try {
-      const saved = JSON.parse(localStorage.getItem('ui-settings') || '{}')
-      return saved.showDIDTooltip ?? false
-    } catch { return false }
-  })
-  const [didTooltipAutoFade, setDidTooltipAutoFade] = useState(() => {
-    try {
-      const saved = JSON.parse(localStorage.getItem('ui-settings') || '{}')
-      return saved.didTooltipAutoFade ?? true
-    } catch { return true }
-  })
+  // settingsService 経由で永続化
+  const [showDIDTooltip, setShowDIDTooltip] = useState(() => getSetting('showMapHoverTooltip') ?? false)
+  const [didTooltipAutoFade, setDidTooltipAutoFade] = useState(() => getSetting('mapHoverTooltipAutoFade') ?? true)
 
-  // localStorage永続化
   useEffect(() => {
-    try {
-      const saved = JSON.parse(localStorage.getItem('ui-settings') || '{}')
-      saved.showDIDTooltip = showDIDTooltip
-      saved.didTooltipAutoFade = didTooltipAutoFade
-      localStorage.setItem('ui-settings', JSON.stringify(saved))
-    } catch { /* ignore */ }
-  }, [showDIDTooltip, didTooltipAutoFade])
+    setSetting('showMapHoverTooltip', showDIDTooltip)
+  }, [showDIDTooltip])
+
+  useEffect(() => {
+    setSetting('mapHoverTooltipAutoFade', didTooltipAutoFade)
+  }, [didTooltipAutoFade])
   // Mobile detection
   const [isMobile, setIsMobile] = useState(() => window.innerWidth <= 768)
   const [fullMapMode, setFullMapMode] = useState(false)
@@ -1411,9 +1400,12 @@ function MainLayout() {
 
               {/* Map Quick Controls - 地図操作のミニマムコントローラー */}
               <div className={`map-quick-controls ${!isMapQuickControlsExpanded ? 'collapsed' : ''}`}>
-                <div
+                <button
+                  type="button"
                   className="map-quick-controls-header"
-                  onClick={() => setIsMapQuickControlsExpanded(!isMapQuickControlsExpanded)}
+                  onClick={() => setIsMapQuickControlsExpanded(v => !v)}
+                  aria-expanded={isMapQuickControlsExpanded}
+                  aria-controls="map-quick-controls-content"
                 >
                   <div className="map-quick-controls-title">
                     <MapIcon size={14} />
@@ -1423,9 +1415,9 @@ function MainLayout() {
                     size={16}
                     className={`map-quick-controls-chevron ${isMapQuickControlsExpanded ? 'expanded' : ''}`}
                   />
-                </div>
+                </button>
                 {isMapQuickControlsExpanded && (
-                  <div className="map-quick-controls-content">
+                  <div id="map-quick-controls-content" className="map-quick-controls-content">
                     <label
                       className="map-quick-control-item"
                       data-tooltip="ホバーで施設情報を表示 [T]"

--- a/src/components/MainLayout/MainLayout.jsx
+++ b/src/components/MainLayout/MainLayout.jsx
@@ -1418,6 +1418,13 @@ function MainLayout() {
                 </button>
                 {isMapQuickControlsExpanded && (
                   <div id="map-quick-controls-content" className="map-quick-controls-content">
+                    <p className="map-quick-controls-desc">
+                      飛行制限エリア（DID・空港・禁止区域など）上にマウスを乗せると、施設情報をポップアップ表示します。
+                      <br />
+                      <span className="map-quick-controls-note">
+                        ※ 危険・制限エリアのみ対象
+                      </span>
+                    </p>
                     <label
                       className="map-quick-control-item"
                       data-tooltip="ホバーで施設情報を表示 [T]"

--- a/src/components/MainLayout/MainLayout.jsx
+++ b/src/components/MainLayout/MainLayout.jsx
@@ -1,6 +1,7 @@
 import { useState, useEffect, useCallback, useRef, useMemo } from 'react'
-import { ChevronDown, Search, Undo2, Redo2, Map as MapIcon, Layers, Settings, Sun, Moon, Menu, Route, Maximize2, Minimize2, X, Download } from 'lucide-react'
+import { ChevronDown, Search, Undo2, Redo2, Map as MapIcon, Layers, Settings, Sun, Moon, Menu, Route, Maximize2, Minimize2, X, Download, Box, Rotate3D, Crosshair, Satellite } from 'lucide-react'
 import { getSetting, setSetting, isDIDAvoidanceModeEnabled, getWaypointNumberingMode } from '../../services/settingsService'
+import { MAP_STYLES, CROSSHAIR_DESIGNS, CROSSHAIR_COLORS, COORDINATE_FORMATS } from '../Map/mapConstants'
 import { getDetailedCollisionResults, getDetailedCollisionResultsWithRestrictionSurfaces, checkWaypointsRestrictionSurfaces, checkAllWaypointsDID, checkAllPolygonsCollision } from '../../services/riskService'
 import { preloadDIDDataForCoordinates, isAllDIDCacheReady } from '../../services/didService'
 import MapComponent from '../Map/Map'
@@ -166,6 +167,31 @@ function MainLayout() {
   useEffect(() => {
     setSetting('mapHoverTooltipAutoFade', didTooltipAutoFade)
   }, [didTooltipAutoFade])
+
+  // Map側から同期される制御API（3D、Crosshair、MapStyle）
+  // Map.jsx内部のhook状態をsidebarから操作するためのブリッジ
+  const [mapControlsState, setMapControlsState] = useState({
+    is3D: false,
+    showCrosshair: false,
+    crosshairDesign: 'square',
+    crosshairColor: '#e53935',
+    crosshairClickMode: true,
+    coordinateFormat: 'dms',
+    mapStyleId: 'osm',
+  })
+  const mapControlsActionsRef = useRef({
+    toggle3D: () => {},
+    setShowCrosshair: () => {},
+    setCrosshairDesign: () => {},
+    setCrosshairColor: () => {},
+    setCrosshairClickMode: () => {},
+    setCoordinateFormat: () => {},
+    setMapStyleId: () => {},
+  })
+  const handleMapControlsReady = useCallback((api) => {
+    mapControlsActionsRef.current = api.actions
+    setMapControlsState(api.state)
+  }, [])
   // Mobile detection
   const [isMobile, setIsMobile] = useState(() => window.innerWidth <= 768)
   const [fullMapMode, setFullMapMode] = useState(false)
@@ -1418,39 +1444,142 @@ function MainLayout() {
                 </button>
                 {isMapQuickControlsExpanded && (
                   <div id="map-quick-controls-content" className="map-quick-controls-content">
-                    <p className="map-quick-controls-desc">
-                      飛行制限エリア（DID・空港・禁止区域など）上にマウスを乗せると、施設情報をポップアップ表示します。
-                      <br />
-                      <span className="map-quick-controls-note">
-                        ※ 危険・制限エリアのみ対象
-                      </span>
-                    </p>
-                    <label
-                      className="map-quick-control-item"
-                      data-tooltip="ホバーで施設情報を表示 [T]"
-                      data-tooltip-pos="right"
-                    >
-                      <input
-                        type="checkbox"
-                        checked={showDIDTooltip}
-                        onChange={(e) => setShowDIDTooltip(e.target.checked)}
-                      />
-                      <span>ツールチップ</span>
-                      <kbd>T</kbd>
-                    </label>
-                    <label
-                      className="map-quick-control-item"
-                      data-tooltip="オフにするとマウスを離すまで表示し続けます"
-                      data-tooltip-pos="right"
-                    >
-                      <input
-                        type="checkbox"
-                        checked={didTooltipAutoFade}
-                        onChange={(e) => setDidTooltipAutoFade(e.target.checked)}
-                        disabled={!showDIDTooltip}
-                      />
-                      <span>自動で消える</span>
-                    </label>
+                    {/* ツールチップセクション */}
+                    <div className="map-quick-controls-section">
+                      <div className="map-quick-controls-section-label">情報表示</div>
+                      <label
+                        className="map-quick-control-item"
+                        data-tooltip="ホバーで施設情報を表示 [T]"
+                        data-tooltip-pos="right"
+                      >
+                        <input
+                          type="checkbox"
+                          checked={showDIDTooltip}
+                          onChange={(e) => setShowDIDTooltip(e.target.checked)}
+                        />
+                        <span>ツールチップ</span>
+                        <kbd>T</kbd>
+                      </label>
+                      <label
+                        className="map-quick-control-item"
+                        data-tooltip="オフにするとマウスを離すまで表示し続けます"
+                        data-tooltip-pos="right"
+                      >
+                        <input
+                          type="checkbox"
+                          checked={didTooltipAutoFade}
+                          onChange={(e) => setDidTooltipAutoFade(e.target.checked)}
+                          disabled={!showDIDTooltip}
+                        />
+                        <span>自動で消える</span>
+                      </label>
+                      <p className="map-quick-controls-desc-note">
+                        対象：危険・制限エリア（DID／空港／禁止区域 等）のみ
+                      </p>
+                    </div>
+
+                    {/* ビューセクション */}
+                    <div className="map-quick-controls-section">
+                      <div className="map-quick-controls-section-label">ビュー</div>
+                      <button
+                        type="button"
+                        className={`map-quick-control-button ${mapControlsState.is3D ? 'active' : ''}`}
+                        onClick={() => mapControlsActionsRef.current.toggle3D()}
+                        data-tooltip={mapControlsState.is3D ? '平面表示に切り替え [3]' : '立体表示に切り替え [3]'}
+                        data-tooltip-pos="right"
+                      >
+                        {mapControlsState.is3D ? <Box size={14} /> : <Rotate3D size={14} />}
+                        <span>{mapControlsState.is3D ? '3D 表示中' : '3D'}</span>
+                        <kbd>3</kbd>
+                      </button>
+                    </div>
+
+                    {/* 中心十字セクション */}
+                    <div className="map-quick-controls-section">
+                      <div className="map-quick-controls-section-label">中心十字</div>
+                      <label
+                        className="map-quick-control-item"
+                        data-tooltip="地図中心に十字線を表示 [X]"
+                        data-tooltip-pos="right"
+                      >
+                        <input
+                          type="checkbox"
+                          checked={mapControlsState.showCrosshair}
+                          onChange={(e) => mapControlsActionsRef.current.setShowCrosshair(e.target.checked)}
+                        />
+                        <span>表示</span>
+                        <kbd>X</kbd>
+                      </label>
+                      {mapControlsState.showCrosshair && (
+                        <>
+                          <div className="map-quick-controls-row">
+                            <select
+                              className="map-quick-controls-select"
+                              value={mapControlsState.crosshairDesign}
+                              onChange={(e) => mapControlsActionsRef.current.setCrosshairDesign(e.target.value)}
+                            >
+                              {CROSSHAIR_DESIGNS.map(d => (
+                                <option key={d.id} value={d.id}>{d.icon} {d.label}</option>
+                              ))}
+                            </select>
+                            <select
+                              className="map-quick-controls-select"
+                              value={mapControlsState.crosshairColor}
+                              onChange={(e) => mapControlsActionsRef.current.setCrosshairColor(e.target.value)}
+                            >
+                              {CROSSHAIR_COLORS.map(c => (
+                                <option key={c.id} value={c.id}>{c.label}</option>
+                              ))}
+                            </select>
+                          </div>
+                          <label className="map-quick-control-item">
+                            <input
+                              type="checkbox"
+                              checked={mapControlsState.crosshairClickMode}
+                              onChange={(e) => mapControlsActionsRef.current.setCrosshairClickMode(e.target.checked)}
+                            />
+                            <span>クリックで座標</span>
+                          </label>
+                          <div className="map-quick-controls-row">
+                            <select
+                              className="map-quick-controls-select full-width"
+                              value={mapControlsState.coordinateFormat}
+                              onChange={(e) => mapControlsActionsRef.current.setCoordinateFormat(e.target.value)}
+                              disabled={!mapControlsState.crosshairClickMode}
+                            >
+                              {COORDINATE_FORMATS.map(f => (
+                                <option key={f.id} value={f.id}>座標形式: {f.label}</option>
+                              ))}
+                            </select>
+                          </div>
+                        </>
+                      )}
+                    </div>
+
+                    {/* 地図スタイルセクション */}
+                    <div className="map-quick-controls-section">
+                      <div className="map-quick-controls-section-label">地図スタイル</div>
+                      <div className="map-quick-controls-style-grid">
+                        {Object.keys(MAP_STYLES).map(key => {
+                          const style = MAP_STYLES[key]
+                          const isActive = mapControlsState.mapStyleId === key
+                          return (
+                            <button
+                              key={key}
+                              type="button"
+                              className={`map-quick-controls-style-btn ${isActive ? 'active' : ''}`}
+                              onClick={() => mapControlsActionsRef.current.setMapStyleId(key)}
+                              data-tooltip={style.name}
+                              data-tooltip-pos="top"
+                            >
+                              {key === 'gsi_photo' && <Satellite size={12} />}
+                              {key !== 'gsi_photo' && <MapIcon size={12} />}
+                              <span>{style.shortName}</span>
+                            </button>
+                          )
+                        })}
+                      </div>
+                    </div>
                   </div>
                 )}
               </div>
@@ -1550,6 +1679,7 @@ function MainLayout() {
             onShowDIDTooltipChange={setShowDIDTooltip}
             didTooltipAutoFade={didTooltipAutoFade}
             onDidTooltipAutoFadeChange={setDidTooltipAutoFade}
+            onMapControlsReady={handleMapControlsReady}
           />
 
           {/* Draw mode hint */}

--- a/src/components/MainLayout/MainLayout.jsx
+++ b/src/components/MainLayout/MainLayout.jsx
@@ -1558,7 +1558,10 @@ function MainLayout() {
 
                     {/* 地図スタイルセクション */}
                     <div className="map-quick-controls-section">
-                      <div className="map-quick-controls-section-label">地図スタイル</div>
+                      <div className="map-quick-controls-section-label">
+                        <span>地図スタイル</span>
+                        <kbd data-tooltip="Mで次へ / Shift+Mで前へ" data-tooltip-pos="top">M</kbd>
+                      </div>
                       <div className="map-quick-controls-style-grid">
                         {Object.keys(MAP_STYLES).map(key => {
                           const style = MAP_STYLES[key]

--- a/src/components/MainLayout/MainLayout.jsx
+++ b/src/components/MainLayout/MainLayout.jsx
@@ -1678,7 +1678,6 @@ function MainLayout() {
             showDIDTooltip={showDIDTooltip}
             onShowDIDTooltipChange={setShowDIDTooltip}
             didTooltipAutoFade={didTooltipAutoFade}
-            onDidTooltipAutoFadeChange={setDidTooltipAutoFade}
             onMapControlsReady={handleMapControlsReady}
           />
 

--- a/src/components/MainLayout/MainLayout.jsx
+++ b/src/components/MainLayout/MainLayout.jsx
@@ -152,6 +152,31 @@ function MainLayout() {
   const [activePanel, setActivePanel] = useState('polygons') // 'polygons' | 'waypoints'
   const [panelHeight, setPanelHeight] = useState(null) // null = auto
   const [isSearchExpanded, setIsSearchExpanded] = useState(true)
+  const [isMapQuickControlsExpanded, setIsMapQuickControlsExpanded] = useState(true)
+
+  // Map quick controls state (sidebar に表示、デフォルトOFF)
+  const [showDIDTooltip, setShowDIDTooltip] = useState(() => {
+    try {
+      const saved = JSON.parse(localStorage.getItem('ui-settings') || '{}')
+      return saved.showDIDTooltip ?? false
+    } catch { return false }
+  })
+  const [didTooltipAutoFade, setDidTooltipAutoFade] = useState(() => {
+    try {
+      const saved = JSON.parse(localStorage.getItem('ui-settings') || '{}')
+      return saved.didTooltipAutoFade ?? true
+    } catch { return true }
+  })
+
+  // localStorage永続化
+  useEffect(() => {
+    try {
+      const saved = JSON.parse(localStorage.getItem('ui-settings') || '{}')
+      saved.showDIDTooltip = showDIDTooltip
+      saved.didTooltipAutoFade = didTooltipAutoFade
+      localStorage.setItem('ui-settings', JSON.stringify(saved))
+    } catch { /* ignore */ }
+  }, [showDIDTooltip, didTooltipAutoFade])
   // Mobile detection
   const [isMobile, setIsMobile] = useState(() => window.innerWidth <= 768)
   const [fullMapMode, setFullMapMode] = useState(false)
@@ -1384,6 +1409,53 @@ function MainLayout() {
                 )}
               </div>
 
+              {/* Map Quick Controls - 地図操作のミニマムコントローラー */}
+              <div className={`map-quick-controls ${!isMapQuickControlsExpanded ? 'collapsed' : ''}`}>
+                <div
+                  className="map-quick-controls-header"
+                  onClick={() => setIsMapQuickControlsExpanded(!isMapQuickControlsExpanded)}
+                >
+                  <div className="map-quick-controls-title">
+                    <MapIcon size={14} />
+                    <span>地図操作</span>
+                  </div>
+                  <ChevronDown
+                    size={16}
+                    className={`map-quick-controls-chevron ${isMapQuickControlsExpanded ? 'expanded' : ''}`}
+                  />
+                </div>
+                {isMapQuickControlsExpanded && (
+                  <div className="map-quick-controls-content">
+                    <label
+                      className="map-quick-control-item"
+                      data-tooltip="ホバーで施設情報を表示 [T]"
+                      data-tooltip-pos="right"
+                    >
+                      <input
+                        type="checkbox"
+                        checked={showDIDTooltip}
+                        onChange={(e) => setShowDIDTooltip(e.target.checked)}
+                      />
+                      <span>ツールチップ</span>
+                      <kbd>T</kbd>
+                    </label>
+                    <label
+                      className="map-quick-control-item"
+                      data-tooltip="オフにするとマウスを離すまで表示し続けます"
+                      data-tooltip-pos="right"
+                    >
+                      <input
+                        type="checkbox"
+                        checked={didTooltipAutoFade}
+                        onChange={(e) => setDidTooltipAutoFade(e.target.checked)}
+                        disabled={!showDIDTooltip}
+                      />
+                      <span>自動で消える</span>
+                    </label>
+                  </div>
+                )}
+              </div>
+
               <div className="panel-tabs">
                 <button
                   className={`tab ${activePanel === 'polygons' ? 'active' : ''}`}
@@ -1475,6 +1547,10 @@ function MainLayout() {
             selectedPolygonId={selectedPolygonId}
             editingPolygon={editingPolygon}
             drawMode={drawMode}
+            showDIDTooltip={showDIDTooltip}
+            onShowDIDTooltipChange={setShowDIDTooltip}
+            didTooltipAutoFade={didTooltipAutoFade}
+            onDidTooltipAutoFadeChange={setDidTooltipAutoFade}
           />
 
           {/* Draw mode hint */}

--- a/src/components/Map/Map.jsx
+++ b/src/components/Map/Map.jsx
@@ -91,7 +91,11 @@ const Map = ({
   onWaypointsBulkDelete,
   selectedPolygonId,
   editingPolygon = null,
-  drawMode = false
+  drawMode = false,
+  showDIDTooltip: externalShowDIDTooltip,
+  onShowDIDTooltipChange,
+  didTooltipAutoFade: externalDidTooltipAutoFade,
+  onDidTooltipAutoFadeChange
 }) => {
   const mapRef = useRef(null)
 
@@ -210,19 +214,11 @@ const Map = ({
 
   // ========================================
   // DIDツールチップ（DIDinJapan準拠）
+  // 状態はMainLayoutから props として受け取る
   // ========================================
-  const [showDIDTooltip, setShowDIDTooltip] = useState(() => {
-    try {
-      const saved = JSON.parse(localStorage.getItem('ui-settings') || '{}')
-      return saved.showDIDTooltip ?? true
-    } catch { return true }
-  })
-  const [didTooltipAutoFade, setDidTooltipAutoFade] = useState(() => {
-    try {
-      const saved = JSON.parse(localStorage.getItem('ui-settings') || '{}')
-      return saved.didTooltipAutoFade ?? true
-    } catch { return true }
-  })
+  const showDIDTooltip = externalShowDIDTooltip ?? false
+  const didTooltipAutoFade = externalDidTooltipAutoFade ?? true
+  const setShowDIDTooltip = onShowDIDTooltipChange || (() => {})
   const showDIDTooltipRef = useRef(showDIDTooltip)
   const didTooltipAutoFadeRef = useRef(didTooltipAutoFade)
   const didPopupRef = useRef(null)
@@ -233,16 +229,6 @@ const Map = ({
   // Ref同期
   useEffect(() => { showDIDTooltipRef.current = showDIDTooltip }, [showDIDTooltip])
   useEffect(() => { didTooltipAutoFadeRef.current = didTooltipAutoFade }, [didTooltipAutoFade])
-
-  // localStorage永続化
-  useEffect(() => {
-    try {
-      const saved = JSON.parse(localStorage.getItem('ui-settings') || '{}')
-      saved.showDIDTooltip = showDIDTooltip
-      saved.didTooltipAutoFade = didTooltipAutoFade
-      localStorage.setItem('ui-settings', JSON.stringify(saved))
-    } catch { /* ignore */ }
-  }, [showDIDTooltip, didTooltipAutoFade])
 
   // Popup初期化（maplibre-glは react-map-gl 経由で既にロード済み）
   useEffect(() => {
@@ -2450,10 +2436,6 @@ const Map = ({
           setCrosshairClickMode={setCrosshairClickMode}
           coordinateFormat={coordinateFormat}
           setCoordinateFormat={setCoordinateFormat}
-          showDIDTooltip={showDIDTooltip}
-          setShowDIDTooltip={setShowDIDTooltip}
-          didTooltipAutoFade={didTooltipAutoFade}
-          setDidTooltipAutoFade={setDidTooltipAutoFade}
           mapStyleId={mapStyleId}
           setMapStyleId={setMapStyleId}
           isMobile={isMobile}
@@ -2473,35 +2455,6 @@ const Map = ({
             <span>Waypoint: ドラッグ=移動 / 右クリック=メニュー</span>
           </>
         )}
-      </div>
-
-      {/* ツールチップ ON/OFF インジケーター */}
-      <div className={styles.tooltipIndicator}>
-        <label
-          className={`${styles.tooltipToggle} ${showDIDTooltip ? styles.active : ''}`}
-          data-tooltip="オフにするとマウスを離すまで表示し続けます"
-          data-tooltip-pos="top"
-        >
-          <input
-            type="checkbox"
-            checked={showDIDTooltip}
-            onChange={(e) => setShowDIDTooltip(e.target.checked)}
-          />
-          <span>ツールチップ [T]</span>
-        </label>
-        <label
-          className={`${styles.tooltipToggle} ${didTooltipAutoFade ? styles.active : ''}`}
-          data-tooltip="オフにするとマウスを離すまで表示し続けます"
-          data-tooltip-pos="top"
-        >
-          <input
-            type="checkbox"
-            checked={didTooltipAutoFade}
-            onChange={(e) => setDidTooltipAutoFade(e.target.checked)}
-            disabled={!showDIDTooltip}
-          />
-          <span>自動で消える</span>
-        </label>
       </div>
 
       {/* Waypoint Context Menu */}

--- a/src/components/Map/Map.jsx
+++ b/src/components/Map/Map.jsx
@@ -55,6 +55,7 @@ import {
   KOKUAREA_MAX_TILES
 } from '../../lib/services/restrictionSurfaces'
 import { loadMapSettings, saveMapSettings } from '../../utils/storage'
+import { checkDIDArea } from '../../services/didService'
 import styles from './Map.module.scss'
 
 // Default center: Tokyo Tower
@@ -207,6 +208,211 @@ const Map = ({
     })
   }, [setLayerVisibility, setViewState])
 
+  // ========================================
+  // DIDツールチップ（DIDinJapan準拠）
+  // ========================================
+  const [showDIDTooltip, setShowDIDTooltip] = useState(() => {
+    try {
+      const saved = JSON.parse(localStorage.getItem('ui-settings') || '{}')
+      return saved.showDIDTooltip ?? true
+    } catch { return true }
+  })
+  const [didTooltipAutoFade, setDidTooltipAutoFade] = useState(() => {
+    try {
+      const saved = JSON.parse(localStorage.getItem('ui-settings') || '{}')
+      return saved.didTooltipAutoFade ?? true
+    } catch { return true }
+  })
+  const showDIDTooltipRef = useRef(showDIDTooltip)
+  const didTooltipAutoFadeRef = useRef(didTooltipAutoFade)
+  const didPopupRef = useRef(null)
+  const didPopupTimerRef = useRef(null)
+  const didDebounceTimerRef = useRef(null)
+  const didRafRef = useRef(null)
+
+  // Ref同期
+  useEffect(() => { showDIDTooltipRef.current = showDIDTooltip }, [showDIDTooltip])
+  useEffect(() => { didTooltipAutoFadeRef.current = didTooltipAutoFade }, [didTooltipAutoFade])
+
+  // localStorage永続化
+  useEffect(() => {
+    try {
+      const saved = JSON.parse(localStorage.getItem('ui-settings') || '{}')
+      saved.showDIDTooltip = showDIDTooltip
+      saved.didTooltipAutoFade = didTooltipAutoFade
+      localStorage.setItem('ui-settings', JSON.stringify(saved))
+    } catch { /* ignore */ }
+  }, [showDIDTooltip, didTooltipAutoFade])
+
+  // Popup初期化（maplibre-glは react-map-gl 経由で既にロード済み）
+  useEffect(() => {
+    // maplibre-glを同期的にrequire（react-map-glの依存で既にバンドルに含まれている）
+    import('maplibre-gl').then((mgl) => {
+      const Popup = mgl.Popup || mgl.default?.Popup
+      if (Popup) {
+        didPopupRef.current = new Popup({
+          closeButton: false,
+          closeOnClick: false,
+          maxWidth: '300px',
+          className: 'did-tooltip-popup'
+        })
+        if (import.meta.env.DEV) {
+          console.log('[Tooltip] Popup initialized successfully')
+        }
+      } else if (import.meta.env.DEV) {
+        console.error('[Tooltip] Popup class not found in maplibre-gl')
+      }
+    }).catch((err) => {
+      if (import.meta.env.DEV) {
+        console.error('[Tooltip] Failed to import maplibre-gl:', err)
+      }
+    })
+    return () => {
+      didPopupRef.current?.remove()
+      if (didPopupTimerRef.current) clearTimeout(didPopupTimerRef.current)
+      if (didDebounceTimerRef.current) clearTimeout(didDebounceTimerRef.current)
+      if (didRafRef.current) cancelAnimationFrame(didRafRef.current)
+    }
+  }, [])
+
+  // DIDツールチップ無効時にPopup削除
+  useEffect(() => {
+    if (!showDIDTooltip) {
+      didPopupRef.current?.remove()
+    }
+  }, [showDIDTooltip])
+
+  // 施設レイヤーのツールチップHTML生成
+  const buildFacilityTooltipHTML = useCallback((props) => {
+    const typeLabels = {
+      government: '政府機関', imperial: '皇室関連', nuclear: '原子力施設',
+      defense: '防衛施設', foreign_mission: '外国公館', prefecture: '都道府県庁',
+      police: '警察施設', prison: '刑務所・拘置所', military_jsdf: '自衛隊施設',
+      energy: 'エネルギー施設', water: '水道施設', infrastructure: '重要インフラ',
+      airport: '空港', international: '国際空港', domestic: '国内空港',
+      military: '軍用飛行場', heliport: 'ヘリポート',
+      emergency: '緊急空域', 'remote-id': 'RemoteID区域',
+      manned_aircraft: '有人機運用区域', radio: '電波干渉区域',
+    }
+    const zoneLabels = { red: 'レッドゾーン', yellow: 'イエローゾーン' }
+    const statusLabels = {
+      operational: '運転中', stopped: '停止中',
+      decommissioning: '廃炉作業中', decommissioned: '廃炉完了',
+    }
+
+    const name = props.name || '不明'
+    const type = typeLabels[props.type] || props.type || ''
+    const zone = zoneLabels[props.zone] || ''
+    const radiusKm = props.radiusKm ? Number(props.radiusKm) : null
+    const status = statusLabels[props.operationalStatus] || ''
+
+    let rows = ''
+    if (type) rows += `<div class="did-popup-row"><span>種類</span><strong>${type}</strong></div>`
+    if (zone) rows += `<div class="did-popup-row"><span>区分</span><strong>${zone}</strong></div>`
+    if (radiusKm) rows += `<div class="did-popup-row"><span>半径</span><strong>${(radiusKm * 1000).toFixed(0)}m</strong></div>`
+    if (status) rows += `<div class="did-popup-row"><span>稼働</span><strong>${status}</strong></div>`
+    if (props.operator) rows += `<div class="did-popup-row"><span>事業者</span><strong>${props.operator}</strong></div>`
+    if (props.description) rows += `<div class="did-popup-row"><span>備考</span><strong>${props.description}</strong></div>`
+
+    return `<div class="did-popup">
+  <div class="did-popup-header">${name}</div>
+  <div class="did-popup-stats">${rows}</div>
+</div>`
+  }, [])
+
+  // 全レイヤー統合ホバーツールチップハンドラ
+  const handleMapHoverTooltip = useCallback((e) => {
+    if (!showDIDTooltipRef.current) {
+      didPopupRef.current?.remove()
+      return
+    }
+    if (!didPopupRef.current) return // Popup未初期化
+    if (!mapRef.current) return
+    if (drawMode || editingPolygon) return
+
+    // RAFスロットリング
+    if (didRafRef.current) return
+    didRafRef.current = requestAnimationFrame(() => {
+      didRafRef.current = null
+
+      // 300msデバウンス
+      if (didDebounceTimerRef.current) clearTimeout(didDebounceTimerRef.current)
+      didDebounceTimerRef.current = setTimeout(async () => {
+        const map = mapRef.current?.getMap()
+        if (!map) return
+        const { lng, lat } = e.lngLat
+
+        // 1. 施設レイヤーのフィーチャーをチェック（即座にヒット判定可能）
+        const facilityLayerIds = [
+          'nuclear-plants-fill', 'prefectures-fill', 'police-fill',
+          'prisons-fill', 'jsdf-fill', 'red-zones-fill', 'yellow-zones-fill',
+          'airport-zones-fill', 'heliports-fill',
+          'emergency-airspace-fill', 'remote-id-zones-fill', 'manned-aircraft-zones-fill',
+        ]
+
+        // 実際にマップ上に存在するレイヤーのみクエリ
+        const existingLayers = facilityLayerIds.filter(id => map.getLayer(id))
+
+        let content = null
+        if (existingLayers.length > 0) {
+          let point = e.point
+          if (!point && e.originalEvent) {
+            const canvas = map.getCanvas()
+            const rect = canvas.getBoundingClientRect()
+            point = {
+              x: e.originalEvent.clientX - rect.left,
+              y: e.originalEvent.clientY - rect.top
+            }
+          }
+
+          if (point) {
+            const features = map.queryRenderedFeatures(point, { layers: existingLayers })
+            if (features && features.length > 0) {
+              content = buildFacilityTooltipHTML(features[0].properties)
+            }
+          }
+        }
+
+        // 2. 施設にヒットしなければDIDチェック（非同期）
+        if (!content) {
+          const result = await checkDIDArea(lat, lng)
+          if (result?.isDID) {
+            content = `<div class="did-popup">
+  <div class="did-popup-header">${result.prefectureName ? `<span class="did-popup-pref">${result.prefectureName}</span>` : ''}${result.area}</div>
+  <div class="did-popup-stats">
+    <div class="did-popup-row"><span>人口</span><strong>${result.population.toLocaleString()}人</strong></div>
+    <div class="did-popup-row"><span>面積</span><strong>${result.menseki.toFixed(2)}km²</strong></div>
+    <div class="did-popup-row"><span>人口密度</span><strong>${result.density.toFixed(1)}人/km²</strong></div>
+    <div class="did-popup-row"><span>コード</span><strong>${result.kenCode}-${result.cityCode}</strong></div>
+  </div>
+</div>`
+          }
+        }
+
+        // 3. ツールチップ表示/非表示
+        if (content && didPopupRef.current) {
+          if (didPopupTimerRef.current) {
+            clearTimeout(didPopupTimerRef.current)
+            didPopupTimerRef.current = null
+          }
+
+          didPopupRef.current
+            .setLngLat([lng, lat])
+            .setHTML(content)
+            .addTo(map)
+
+          if (didTooltipAutoFadeRef.current) {
+            didPopupTimerRef.current = setTimeout(() => {
+              didPopupRef.current?.remove()
+            }, 2000)
+          }
+        } else {
+          didPopupRef.current?.remove()
+        }
+      }, 300)
+    })
+  }, [drawMode, editingPolygon, buildFacilityTooltipHTML])
+
   // キーボードショートカット
   useMapKeyboardShortcuts({
     toggle3D,
@@ -214,7 +420,8 @@ const Map = ({
     toggleAirportOverlay,
     setShowCrosshair,
     mapStyleId,
-    setMapStyleId
+    setMapStyleId,
+    setShowDIDTooltip
   })
 
   // toggleLayer, toggleAirportOverlay, toggleGroupLayers, toggleFavoriteGroup
@@ -834,7 +1041,20 @@ const Map = ({
     }
 
     if (polygonFeature) {
-      onPolygonSelect?.(polygonFeature.properties.id)
+      const polygonId = polygonFeature.properties.id
+      onPolygonSelect?.(polygonId)
+      // クリックでポリゴンツールチップを即時表示
+      const polygon = polygons.find(p => p.id === polygonId)
+      if (polygon) {
+        const area = turf.area(polygon.geometry)
+        const waypointCount = waypoints.filter(wp => wp.polygonId === polygon.id).length
+        setTooltip({
+          isVisible: true,
+          position: { x: e.originalEvent.clientX, y: e.originalEvent.clientY },
+          data: { ...polygon, area, waypointCount },
+          type: 'polygon'
+        })
+      }
       return
     }
 
@@ -1592,6 +1812,8 @@ const Map = ({
           if (!isSelecting) {
             handlePolygonHover(e)
           }
+          // 全レイヤーツールチップ（DID + 施設）
+          handleMapHoverTooltip(e)
         }}
         onMouseUp={selectionHandlers.onMouseUp}
         onMouseLeave={handlePolygonHoverEnd}
@@ -2136,6 +2358,16 @@ const Map = ({
                         if (editingPolygon) return
                         e.originalEvent.stopPropagation()
                         onWaypointClick?.(wp)
+                        // クリックでツールチップを即時表示
+                        if (!drawMode) {
+                          const restrictions = getWaypointAirspaceRestrictions(wp)
+                          setTooltip({
+                            isVisible: true,
+                            position: { x: e.originalEvent.clientX, y: e.originalEvent.clientY },
+                            data: { ...wp, airspaceRestrictions: restrictions },
+                            type: 'waypoint'
+                          })
+                        }
                     }}
                 >
                     <div
@@ -2218,6 +2450,10 @@ const Map = ({
           setCrosshairClickMode={setCrosshairClickMode}
           coordinateFormat={coordinateFormat}
           setCoordinateFormat={setCoordinateFormat}
+          showDIDTooltip={showDIDTooltip}
+          setShowDIDTooltip={setShowDIDTooltip}
+          didTooltipAutoFade={didTooltipAutoFade}
+          setDidTooltipAutoFade={setDidTooltipAutoFade}
           mapStyleId={mapStyleId}
           setMapStyleId={setMapStyleId}
           isMobile={isMobile}
@@ -2237,6 +2473,35 @@ const Map = ({
             <span>Waypoint: ドラッグ=移動 / 右クリック=メニュー</span>
           </>
         )}
+      </div>
+
+      {/* ツールチップ ON/OFF インジケーター */}
+      <div className={styles.tooltipIndicator}>
+        <label
+          className={`${styles.tooltipToggle} ${showDIDTooltip ? styles.active : ''}`}
+          data-tooltip="オフにするとマウスを離すまで表示し続けます"
+          data-tooltip-pos="top"
+        >
+          <input
+            type="checkbox"
+            checked={showDIDTooltip}
+            onChange={(e) => setShowDIDTooltip(e.target.checked)}
+          />
+          <span>ツールチップ [T]</span>
+        </label>
+        <label
+          className={`${styles.tooltipToggle} ${didTooltipAutoFade ? styles.active : ''}`}
+          data-tooltip="オフにするとマウスを離すまで表示し続けます"
+          data-tooltip-pos="top"
+        >
+          <input
+            type="checkbox"
+            checked={didTooltipAutoFade}
+            onChange={(e) => setDidTooltipAutoFade(e.target.checked)}
+            disabled={!showDIDTooltip}
+          />
+          <span>自動で消える</span>
+        </label>
       </div>
 
       {/* Waypoint Context Menu */}

--- a/src/components/Map/Map.jsx
+++ b/src/components/Map/Map.jsx
@@ -261,12 +261,25 @@ const Map = ({
     }
   }, [])
 
-  // DIDツールチップ無効時にPopup削除
+  // DIDツールチップ無効化／描画モード遷移時にPopup削除
   useEffect(() => {
-    if (!showDIDTooltip) {
+    if (!showDIDTooltip || drawMode || editingPolygon) {
       didPopupRef.current?.remove()
+      // 進行中のデバウンスタイマーもキャンセル
+      if (didDebounceTimerRef.current) {
+        clearTimeout(didDebounceTimerRef.current)
+        didDebounceTimerRef.current = null
+      }
     }
-  }, [showDIDTooltip])
+  }, [showDIDTooltip, drawMode, editingPolygon])
+
+  // HTMLエスケープヘルパー（XSS対策）
+  // GeoJSON propertiesは外部由来の可能性があるため必須
+  const escapeHTML = useCallback((s) => {
+    return String(s ?? '').replace(/[&<>"']/g, (m) => ({
+      '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;', "'": '&#39;'
+    }[m]))
+  }, [])
 
   // 施設レイヤーのツールチップHTML生成
   const buildFacilityTooltipHTML = useCallback((props) => {
@@ -286,25 +299,25 @@ const Map = ({
       decommissioning: '廃炉作業中', decommissioned: '廃炉完了',
     }
 
-    const name = props.name || '不明'
-    const type = typeLabels[props.type] || props.type || ''
-    const zone = zoneLabels[props.zone] || ''
+    const name = escapeHTML(props.name || '不明')
+    const type = escapeHTML(typeLabels[props.type] || props.type || '')
+    const zone = zoneLabels[props.zone] || '' // 内部マップ由来なのでエスケープ不要
     const radiusKm = props.radiusKm ? Number(props.radiusKm) : null
-    const status = statusLabels[props.operationalStatus] || ''
+    const status = statusLabels[props.operationalStatus] || '' // 内部マップ由来
 
     let rows = ''
     if (type) rows += `<div class="did-popup-row"><span>種類</span><strong>${type}</strong></div>`
     if (zone) rows += `<div class="did-popup-row"><span>区分</span><strong>${zone}</strong></div>`
     if (radiusKm) rows += `<div class="did-popup-row"><span>半径</span><strong>${(radiusKm * 1000).toFixed(0)}m</strong></div>`
     if (status) rows += `<div class="did-popup-row"><span>稼働</span><strong>${status}</strong></div>`
-    if (props.operator) rows += `<div class="did-popup-row"><span>事業者</span><strong>${props.operator}</strong></div>`
-    if (props.description) rows += `<div class="did-popup-row"><span>備考</span><strong>${props.description}</strong></div>`
+    if (props.operator) rows += `<div class="did-popup-row"><span>事業者</span><strong>${escapeHTML(props.operator)}</strong></div>`
+    if (props.description) rows += `<div class="did-popup-row"><span>備考</span><strong>${escapeHTML(props.description)}</strong></div>`
 
     return `<div class="did-popup">
   <div class="did-popup-header">${name}</div>
   <div class="did-popup-stats">${rows}</div>
 </div>`
-  }, [])
+  }, [escapeHTML])
 
   // 全レイヤー統合ホバーツールチップハンドラ
   const handleMapHoverTooltip = useCallback((e) => {
@@ -321,9 +334,12 @@ const Map = ({
     didRafRef.current = requestAnimationFrame(() => {
       didRafRef.current = null
 
-      // 300msデバウンス
+      // 300msデバウンス（前回のタイマーをクリア）
       if (didDebounceTimerRef.current) clearTimeout(didDebounceTimerRef.current)
       didDebounceTimerRef.current = setTimeout(async () => {
+        didDebounceTimerRef.current = null
+        // タイマー発火時に再度トグル状態を確認（OFFされていたらスキップ）
+        if (!showDIDTooltipRef.current) return
         const map = mapRef.current?.getMap()
         if (!map) return
         const { lng, lat } = e.lngLat
@@ -362,14 +378,20 @@ const Map = ({
         // 2. 施設にヒットしなければDIDチェック（非同期）
         if (!content) {
           const result = await checkDIDArea(lat, lng)
+          // await解決後に再度トグル状態を確認（OFFされていたら描画スキップ）
+          if (!showDIDTooltipRef.current || !didPopupRef.current) return
           if (result?.isDID) {
+            const prefName = escapeHTML(result.prefectureName || '')
+            const area = escapeHTML(result.area || '')
+            const kenCode = escapeHTML(result.kenCode || '')
+            const cityCode = escapeHTML(result.cityCode || '')
             content = `<div class="did-popup">
-  <div class="did-popup-header">${result.prefectureName ? `<span class="did-popup-pref">${result.prefectureName}</span>` : ''}${result.area}</div>
+  <div class="did-popup-header">${prefName ? `<span class="did-popup-pref">${prefName}</span>` : ''}${area}</div>
   <div class="did-popup-stats">
     <div class="did-popup-row"><span>人口</span><strong>${result.population.toLocaleString()}人</strong></div>
     <div class="did-popup-row"><span>面積</span><strong>${result.menseki.toFixed(2)}km²</strong></div>
     <div class="did-popup-row"><span>人口密度</span><strong>${result.density.toFixed(1)}人/km²</strong></div>
-    <div class="did-popup-row"><span>コード</span><strong>${result.kenCode}-${result.cityCode}</strong></div>
+    <div class="did-popup-row"><span>コード</span><strong>${kenCode}-${cityCode}</strong></div>
   </div>
 </div>`
           }
@@ -390,6 +412,7 @@ const Map = ({
           if (didTooltipAutoFadeRef.current) {
             didPopupTimerRef.current = setTimeout(() => {
               didPopupRef.current?.remove()
+              didPopupTimerRef.current = null
             }, 2000)
           }
         } else {
@@ -397,7 +420,7 @@ const Map = ({
         }
       }, 300)
     })
-  }, [drawMode, editingPolygon, buildFacilityTooltipHTML])
+  }, [drawMode, editingPolygon, buildFacilityTooltipHTML, escapeHTML])
 
   // キーボードショートカット
   useMapKeyboardShortcuts({

--- a/src/components/Map/Map.jsx
+++ b/src/components/Map/Map.jsx
@@ -117,8 +117,6 @@ const Map = ({
     setIsMapReady,
     mapStyleId,
     setMapStyleId,
-    showStylePicker,
-    setShowStylePicker,
     mobileControlsExpanded,
     setMobileControlsExpanded,
     rainCloudSource,

--- a/src/components/Map/Map.jsx
+++ b/src/components/Map/Map.jsx
@@ -95,7 +95,8 @@ const Map = ({
   showDIDTooltip: externalShowDIDTooltip,
   onShowDIDTooltipChange,
   didTooltipAutoFade: externalDidTooltipAutoFade,
-  onDidTooltipAutoFadeChange
+  onDidTooltipAutoFadeChange,
+  onMapControlsReady
 }) => {
   const mapRef = useRef(null)
 
@@ -432,6 +433,50 @@ const Map = ({
     setMapStyleId,
     setShowDIDTooltip
   })
+
+  // Map制御状態を親（MainLayout）にブリッジ
+  // sidebarの「地図操作」から3D/Crosshair/MapStyleを操作可能にする
+  const onMapControlsReadyRef = useRef(onMapControlsReady)
+  onMapControlsReadyRef.current = onMapControlsReady
+
+  // アクション（setters）は初回のみ登録（stable reference想定）
+  useEffect(() => {
+    onMapControlsReadyRef.current?.({
+      state: {
+        is3D: layerVisibility.is3D,
+        showCrosshair,
+        crosshairDesign,
+        crosshairColor,
+        crosshairClickMode,
+        coordinateFormat,
+        mapStyleId,
+      },
+      actions: {
+        toggle3D,
+        setShowCrosshair,
+        setCrosshairDesign,
+        setCrosshairColor,
+        setCrosshairClickMode,
+        setCoordinateFormat,
+        setMapStyleId,
+      }
+    })
+  }, [
+    layerVisibility.is3D,
+    showCrosshair,
+    crosshairDesign,
+    crosshairColor,
+    crosshairClickMode,
+    coordinateFormat,
+    mapStyleId,
+    toggle3D,
+    setShowCrosshair,
+    setCrosshairDesign,
+    setCrosshairColor,
+    setCrosshairClickMode,
+    setCoordinateFormat,
+    setMapStyleId,
+  ])
 
   // toggleLayer, toggleAirportOverlay, toggleGroupLayers, toggleFavoriteGroup
   // → useLayerVisibility hook から提供されるため削除
@@ -2446,25 +2491,10 @@ const Map = ({
           toggleLayer={toggleLayer}
           toggleAirportOverlay={toggleAirportOverlay}
           toggleGroupLayers={toggleGroupLayers}
-          toggle3D={toggle3D}
           favoriteGroups={favoriteGroups}
           toggleFavoriteGroup={toggleFavoriteGroup}
-          showCrosshair={showCrosshair}
-          setShowCrosshair={setShowCrosshair}
-          crosshairDesign={crosshairDesign}
-          setCrosshairDesign={setCrosshairDesign}
-          crosshairColor={crosshairColor}
-          setCrosshairColor={setCrosshairColor}
-          crosshairClickMode={crosshairClickMode}
-          setCrosshairClickMode={setCrosshairClickMode}
-          coordinateFormat={coordinateFormat}
-          setCoordinateFormat={setCoordinateFormat}
-          mapStyleId={mapStyleId}
-          setMapStyleId={setMapStyleId}
           isMobile={isMobile}
           mobileControlsExpanded={mobileControlsExpanded}
-          showStylePicker={showStylePicker}
-          setShowStylePicker={setShowStylePicker}
         />
       </div>
 

--- a/src/components/Map/Map.jsx
+++ b/src/components/Map/Map.jsx
@@ -1,4 +1,4 @@
-import { useState, useCallback, useRef, useEffect, useMemo } from 'react'
+import { useCallback, useRef, useEffect, useMemo } from 'react'
 import MapGL, { NavigationControl, ScaleControl, Marker, Source, Layer, AttributionControl } from 'react-map-gl/maplibre'
 import { Box, Rotate3D, Plane, ShieldAlert, Users, Map as MapIcon, Layers, Building2, Landmark, Satellite, Settings2, X, AlertTriangle, Radio, MapPinned, CloudRain, Wind, Wifi, Crosshair, Signal, Zap, Building, Shield, Lock, Target, Star } from 'lucide-react'
 import * as turf from '@turf/turf'
@@ -95,7 +95,6 @@ const Map = ({
   showDIDTooltip: externalShowDIDTooltip,
   onShowDIDTooltipChange,
   didTooltipAutoFade: externalDidTooltipAutoFade,
-  onDidTooltipAutoFadeChange,
   onMapControlsReady
 }) => {
   const mapRef = useRef(null)

--- a/src/components/Map/Map.module.scss
+++ b/src/components/Map/Map.module.scss
@@ -361,6 +361,67 @@
   }
 }
 
+.tooltipIndicator {
+  position: absolute;
+  top: 10px;
+  left: 50px;
+  display: flex;
+  gap: 6px;
+  z-index: 10;
+}
+
+.tooltipToggle {
+  display: flex;
+  align-items: center;
+  gap: 5px;
+  padding: 5px 10px;
+  background: rgba(0, 0, 0, 0.7);
+  backdrop-filter: blur(8px);
+  -webkit-backdrop-filter: blur(8px);
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  border-radius: 16px;
+  font-size: 12px;
+  color: rgba(255, 255, 255, 0.7);
+  cursor: pointer;
+  user-select: none;
+  transition: all 0.2s ease;
+  white-space: nowrap;
+
+  input[type="checkbox"] {
+    accent-color: #3b82f6;
+    margin: 0;
+    cursor: pointer;
+  }
+
+  &.active {
+    color: #fff;
+    border-color: rgba(59, 130, 246, 0.5);
+    background: rgba(59, 130, 246, 0.2);
+  }
+
+  &:hover {
+    background: rgba(0, 0, 0, 0.85);
+  }
+}
+
+:root[data-theme='light'] {
+  .tooltipToggle {
+    background: rgba(255, 255, 255, 0.85);
+    border-color: rgba(0, 0, 0, 0.1);
+    color: rgba(0, 0, 0, 0.6);
+
+    &.active {
+      color: #1a1a1a;
+      border-color: rgba(59, 130, 246, 0.4);
+      background: rgba(59, 130, 246, 0.1);
+    }
+
+    &:hover {
+      background: rgba(255, 255, 255, 0.95);
+    }
+  }
+}
+
 .mapControls {
   position: absolute;
   top: 10px;

--- a/src/components/Map/Map.module.scss
+++ b/src/components/Map/Map.module.scss
@@ -361,67 +361,6 @@
   }
 }
 
-.tooltipIndicator {
-  position: absolute;
-  top: 10px;
-  left: 50px;
-  display: flex;
-  gap: 6px;
-  z-index: 10;
-}
-
-.tooltipToggle {
-  display: flex;
-  align-items: center;
-  gap: 5px;
-  padding: 5px 10px;
-  background: rgba(0, 0, 0, 0.7);
-  backdrop-filter: blur(8px);
-  -webkit-backdrop-filter: blur(8px);
-  border: 1px solid rgba(255, 255, 255, 0.1);
-  border-radius: 16px;
-  font-size: 12px;
-  color: rgba(255, 255, 255, 0.7);
-  cursor: pointer;
-  user-select: none;
-  transition: all 0.2s ease;
-  white-space: nowrap;
-
-  input[type="checkbox"] {
-    accent-color: #3b82f6;
-    margin: 0;
-    cursor: pointer;
-  }
-
-  &.active {
-    color: #fff;
-    border-color: rgba(59, 130, 246, 0.5);
-    background: rgba(59, 130, 246, 0.2);
-  }
-
-  &:hover {
-    background: rgba(0, 0, 0, 0.85);
-  }
-}
-
-:root[data-theme='light'] {
-  .tooltipToggle {
-    background: rgba(255, 255, 255, 0.85);
-    border-color: rgba(0, 0, 0, 0.1);
-    color: rgba(0, 0, 0, 0.6);
-
-    &.active {
-      color: #1a1a1a;
-      border-color: rgba(59, 130, 246, 0.4);
-      background: rgba(59, 130, 246, 0.1);
-    }
-
-    &:hover {
-      background: rgba(255, 255, 255, 0.95);
-    }
-  }
-}
-
 .mapControls {
   position: absolute;
   top: 10px;

--- a/src/components/Map/MapControls.jsx
+++ b/src/components/Map/MapControls.jsx
@@ -28,10 +28,6 @@ const MapControls = ({
   setCrosshairClickMode,
   coordinateFormat,
   setCoordinateFormat,
-  showDIDTooltip,
-  setShowDIDTooltip,
-  didTooltipAutoFade,
-  setDidTooltipAutoFade,
   mapStyleId,
   setMapStyleId,
   isMobile,
@@ -534,27 +530,6 @@ const MapControls = ({
                 </div>
               </div>
             </ControlGroup>
-
-            {/* DIDツールチップ設定 */}
-            <div className={styles.tooltipSettings}>
-              <label className={styles.crosshairCheckbox}>
-                <input
-                  type="checkbox"
-                  checked={showDIDTooltip}
-                  onChange={(e) => setShowDIDTooltip(e.target.checked)}
-                />
-                <span>ツールチップ [T]</span>
-              </label>
-              <label className={styles.crosshairCheckbox} data-tooltip="オフにするとマウスを離すまで表示し続けます" data-tooltip-pos="left">
-                <input
-                  type="checkbox"
-                  checked={didTooltipAutoFade}
-                  onChange={(e) => setDidTooltipAutoFade(e.target.checked)}
-                  disabled={!showDIDTooltip}
-                />
-                <span>自動で消える</span>
-              </label>
-            </div>
 
             {/* 地図スタイル切り替え */}
             <div className={styles.stylePickerContainer}>

--- a/src/components/Map/MapControls.jsx
+++ b/src/components/Map/MapControls.jsx
@@ -28,6 +28,10 @@ const MapControls = ({
   setCrosshairClickMode,
   coordinateFormat,
   setCoordinateFormat,
+  showDIDTooltip,
+  setShowDIDTooltip,
+  didTooltipAutoFade,
+  setDidTooltipAutoFade,
   mapStyleId,
   setMapStyleId,
   isMobile,
@@ -437,7 +441,7 @@ const MapControls = ({
             <button
               className={`${styles.toggleButton} ${layerVisibility.showRadioZones ? styles.activeRadioZones : ''}`}
               onClick={() => toggleLayer('showRadioZones')}
-              data-tooltip="電波利用に注意が必要な区域 [T]"
+              data-tooltip="電波利用に注意が必要な区域"
               data-tooltip-pos="left"
             >
               <Wifi size={18} />
@@ -530,6 +534,27 @@ const MapControls = ({
                 </div>
               </div>
             </ControlGroup>
+
+            {/* DIDツールチップ設定 */}
+            <div className={styles.tooltipSettings}>
+              <label className={styles.crosshairCheckbox}>
+                <input
+                  type="checkbox"
+                  checked={showDIDTooltip}
+                  onChange={(e) => setShowDIDTooltip(e.target.checked)}
+                />
+                <span>ツールチップ [T]</span>
+              </label>
+              <label className={styles.crosshairCheckbox} data-tooltip="オフにするとマウスを離すまで表示し続けます" data-tooltip-pos="left">
+                <input
+                  type="checkbox"
+                  checked={didTooltipAutoFade}
+                  onChange={(e) => setDidTooltipAutoFade(e.target.checked)}
+                  disabled={!showDIDTooltip}
+                />
+                <span>自動で消える</span>
+              </label>
+            </div>
 
             {/* 地図スタイル切り替え */}
             <div className={styles.stylePickerContainer}>

--- a/src/components/Map/MapControls.jsx
+++ b/src/components/Map/MapControls.jsx
@@ -4,7 +4,7 @@
  * 地図レイヤーコントロールパネル
  */
 
-import { Layers, Users, ShieldAlert, Plane, CloudRain, Signal, Building2, Zap, Building, Shield, Lock, Target, Landmark, AlertTriangle, Radio, MapPinned, Wind, Wifi } from 'lucide-react'
+import { Layers, Users, ShieldAlert, Plane, CloudRain, Signal, Building2, Zap, Building, Shield, Lock, Target, Landmark, AlertTriangle, Radio, MapPinned, Map as MapIcon, Wind, Wifi } from 'lucide-react'
 import ControlGroup from './ControlGroup'
 import styles from './Map.module.scss'
 

--- a/src/components/Map/MapControls.jsx
+++ b/src/components/Map/MapControls.jsx
@@ -4,9 +4,8 @@
  * 地図レイヤーコントロールパネル
  */
 
-import { Layers, Users, ShieldAlert, Plane, CloudRain, Signal, Settings2, Building2, Zap, Building, Shield, Lock, Target, Landmark, AlertTriangle, Radio, MapPinned, Map as MapIcon, Wind, Wifi, Box, Rotate3D, Crosshair, Satellite } from 'lucide-react'
+import { Layers, Users, ShieldAlert, Plane, CloudRain, Signal, Building2, Zap, Building, Shield, Lock, Target, Landmark, AlertTriangle, Radio, MapPinned, Wind, Wifi } from 'lucide-react'
 import ControlGroup from './ControlGroup'
-import { CROSSHAIR_DESIGNS, CROSSHAIR_COLORS, COORDINATE_FORMATS, MAP_STYLES } from './mapConstants'
 import styles from './Map.module.scss'
 
 const MapControls = ({
@@ -15,25 +14,10 @@ const MapControls = ({
   toggleLayer,
   toggleAirportOverlay,
   toggleGroupLayers,
-  toggle3D,
   favoriteGroups,
   toggleFavoriteGroup,
-  showCrosshair,
-  setShowCrosshair,
-  crosshairDesign,
-  setCrosshairDesign,
-  crosshairColor,
-  setCrosshairColor,
-  crosshairClickMode,
-  setCrosshairClickMode,
-  coordinateFormat,
-  setCoordinateFormat,
-  mapStyleId,
-  setMapStyleId,
   isMobile,
   mobileControlsExpanded,
-  showStylePicker,
-  setShowStylePicker
 }) => {
   return (
         <div className={`${styles.controlsGroup} ${isMobile && !mobileControlsExpanded ? styles.hidden : ''}`}>
@@ -454,115 +438,7 @@ const MapControls = ({
             </button>
           </ControlGroup>
 
-          {/* グループ5: Map設定 */}
-          <ControlGroup
-            id="map-settings"
-            icon={<Settings2 size={18} />}
-            label="Map設定"
-            tooltip="地図表示の各種設定"
-            defaultExpanded={false}
-            favoritable={true}
-            isFavorite={favoriteGroups.has('map-settings')}
-            onFavoriteToggle={() => toggleFavoriteGroup('map-settings')}
-          >
-            <button
-              className={`${styles.toggleButton} ${layerVisibility.is3D ? styles.active : ''}`}
-              onClick={toggle3D}
-              data-tooltip={layerVisibility.is3D ? '地形を平面で表示 [3]' : '地形を立体で表示 [3]'}
-              data-tooltip-pos="left"
-            >
-              {layerVisibility.is3D ? <Box size={18} /> : <Rotate3D size={18} />}
-              <span className={styles.buttonLabel}>{layerVisibility.is3D ? '2D' : '3D'}</span>
-            </button>
-            {/* クロスヘア設定 */}
-            <ControlGroup
-              id="crosshair"
-              icon={<Crosshair size={18} />}
-              label="中心十字"
-              tooltip="地図中心の十字線を表示 [X]"
-              groupToggle={true}
-              groupEnabled={showCrosshair}
-              onGroupToggle={setShowCrosshair}
-              defaultExpanded={false}
-            >
-              <div className={styles.crosshairSettings}>
-                <div className={styles.crosshairRow}>
-                  <span className={styles.crosshairLabel}>表示</span>
-                  <select
-                    className={styles.crosshairSelect}
-                    value={crosshairDesign}
-                    onChange={(e) => setCrosshairDesign(e.target.value)}
-                  >
-                    {CROSSHAIR_DESIGNS.map(d => (
-                      <option key={d.id} value={d.id}>{d.icon} {d.label}</option>
-                    ))}
-                  </select>
-                  <select
-                    className={styles.crosshairColorSelect}
-                    value={crosshairColor}
-                    onChange={(e) => setCrosshairColor(e.target.value)}
-                    style={{ '--selected-color': crosshairColor }}
-                  >
-                    {CROSSHAIR_COLORS.map(c => (
-                      <option key={c.id} value={c.id}>{c.label}</option>
-                    ))}
-                  </select>
-                </div>
-                <div className={styles.crosshairRow}>
-                  <label className={styles.crosshairCheckbox}>
-                    <input
-                      type="checkbox"
-                      checked={crosshairClickMode}
-                      onChange={(e) => setCrosshairClickMode(e.target.checked)}
-                    />
-                    <span>クリックで座標</span>
-                  </label>
-                  <select
-                    className={styles.crosshairSelect}
-                    value={coordinateFormat}
-                    onChange={(e) => setCoordinateFormat(e.target.value)}
-                    disabled={!crosshairClickMode}
-                  >
-                    {COORDINATE_FORMATS.map(f => (
-                      <option key={f.id} value={f.id}>{f.label}</option>
-                    ))}
-                  </select>
-                </div>
-              </div>
-            </ControlGroup>
-
-            {/* 地図スタイル切り替え */}
-            <div className={styles.stylePickerContainer}>
-              <button
-                className={`${styles.toggleButton} ${showStylePicker ? styles.active : ''}`}
-                onClick={() => setShowStylePicker(!showStylePicker)}
-                data-tooltip="地図の表示スタイルを切り替え [M: 次へ / Shift+M: 前へ]"
-                data-tooltip-pos="left"
-              >
-                <Layers size={18} />
-                <span className={styles.buttonLabel}>スタイル</span>
-              </button>
-              {showStylePicker && (
-                <div className={styles.stylePicker}>
-                  {Object.values(MAP_STYLES).map(styleOption => (
-                    <button
-                      key={styleOption.id}
-                      className={`${styles.styleOption} ${mapStyleId === styleOption.id ? styles.activeStyle : ''}`}
-                      onClick={() => {
-                        setMapStyleId(styleOption.id)
-                        setShowStylePicker(false)
-                      }}
-                    >
-                      <span className={styles.styleIcon}>
-                        {styleOption.id === 'gsi_photo' ? <Satellite size={16} /> : <MapIcon size={16} />}
-                      </span>
-                      <span className={styles.styleName}>{styleOption.shortName}</span>
-                    </button>
-                  ))}
-                </div>
-              )}
-            </div>
-          </ControlGroup>
+          {/* Map設定 (3D/中心十字/スタイル) はサイドバー「地図操作」に移動済み */}
         </div>
   )
 }

--- a/src/components/Map/hooks/useMapKeyboardShortcuts.js
+++ b/src/components/Map/hooks/useMapKeyboardShortcuts.js
@@ -15,6 +15,7 @@ import { MAP_STYLES } from '../mapConstants'
  * @param {Function} params.setShowCrosshair - Set crosshair visibility
  * @param {string} params.mapStyleId - Current map style ID
  * @param {Function} params.setMapStyleId - Set map style ID
+ * @param {Function} params.setShowDIDTooltip - Toggle DID tooltip
  */
 export const useMapKeyboardShortcuts = ({
   toggle3D,
@@ -22,7 +23,8 @@ export const useMapKeyboardShortcuts = ({
   toggleAirportOverlay,
   setShowCrosshair,
   mapStyleId,
-  setMapStyleId
+  setMapStyleId,
+  setShowDIDTooltip
 }) => {
   useEffect(() => {
     const handleKeyDown = (e) => {
@@ -96,9 +98,9 @@ export const useMapKeyboardShortcuts = ({
           break
         // 'o' key is reserved for Weather Forecast panel (MainLayout.jsx)
         // Wind toggle will be re-enabled when the feature is implemented
-        case 't': // Radio zones (LTE) toggle
+        case 't': // DIDツールチップ表示切り替え
           e.preventDefault()
-          toggleLayer('showRadioZones')
+          setShowDIDTooltip(prev => !prev)
           break
         case 'l': // Network coverage (LTE/5G) toggle
           e.preventDefault()
@@ -136,5 +138,5 @@ export const useMapKeyboardShortcuts = ({
 
     window.addEventListener('keydown', handleKeyDown)
     return () => window.removeEventListener('keydown', handleKeyDown)
-  }, [toggle3D, toggleLayer, toggleAirportOverlay, mapStyleId, setMapStyleId, setShowCrosshair])
+  }, [toggle3D, toggleLayer, toggleAirportOverlay, mapStyleId, setMapStyleId, setShowCrosshair, setShowDIDTooltip])
 }

--- a/src/components/MapTooltip/MapTooltip.jsx
+++ b/src/components/MapTooltip/MapTooltip.jsx
@@ -19,9 +19,15 @@ import styles from './MapTooltip.module.scss'
  */
 export const MapTooltip = ({ isVisible, position, data, type, onClose }) => {
   const tooltipRef = useRef(null)
-  const [adjustedPosition, setAdjustedPosition] = useState(position)
-  const [arrowDir, setArrowDir] = useState('none')
-  const [isPositioned, setIsPositioned] = useState(false)
+  // 配置計算結果を1つの state にまとめることで setState カスケードを回避
+  const [layout, setLayout] = useState({
+    position: position || { x: 0, y: 0 },
+    arrowDir: 'none',
+    isPositioned: false,
+  })
+  const adjustedPosition = layout.position
+  const arrowDir = layout.arrowDir
+  const isPositioned = layout.isPositioned
 
   // ESCキーで閉じる
   useEffect(() => {
@@ -80,9 +86,13 @@ export const MapTooltip = ({ isVisible, position, data, type, onClose }) => {
         y = window.innerHeight - panelHeight - MARGIN
       }
 
-      setArrowDir(dir)
-      setAdjustedPosition({ x, y })
-      setIsPositioned(true)
+      // DOM計測後の位置確定のため useLayoutEffect + setState は canonical パターン
+      // eslint-disable-next-line react-hooks/set-state-in-effect
+      setLayout({
+        position: { x, y },
+        arrowDir: dir,
+        isPositioned: true,
+      })
     }
   }, [position, isVisible])
 

--- a/src/components/MapTooltip/MapTooltip.jsx
+++ b/src/components/MapTooltip/MapTooltip.jsx
@@ -20,6 +20,8 @@ import styles from './MapTooltip.module.scss'
 export const MapTooltip = ({ isVisible, position, data, type, onClose }) => {
   const tooltipRef = useRef(null)
   const [adjustedPosition, setAdjustedPosition] = useState(position)
+  const [arrowDir, setArrowDir] = useState('none')
+  const [isPositioned, setIsPositioned] = useState(false)
 
   // ESCキーで閉じる
   useEffect(() => {
@@ -41,48 +43,50 @@ export const MapTooltip = ({ isVisible, position, data, type, onClose }) => {
     }
   }, [isVisible, onClose])
 
-  // Calculate and update position after DOM mount to ensure tooltip stays in viewport
+  // 矢印付き配置ロジック（CoordinateDisplay準拠）
+  // ホバー位置から右横→左横→下とフォールバック
   useLayoutEffect(() => {
     if (tooltipRef.current && position) {
       const rect = tooltipRef.current.getBoundingClientRect()
-      const MARGIN = 10
-      const OFFSET_X = 15
-      const OFFSET_Y = 15
+      const MARGIN = 16
+      const ARROW_SIZE = 8
+      const GAP = 12
 
-      let x = position.x + OFFSET_X
-      let y = position.y + OFFSET_Y
+      const panelWidth = rect.width || 280
+      const panelHeight = rect.height || 120
 
-      // Check right boundary
-      if (x + rect.width > window.innerWidth - MARGIN) {
-        x = position.x - rect.width - OFFSET_X
+      // デフォルト: ホバー位置の右横に配置
+      let x = position.x + ARROW_SIZE + GAP
+      let y = position.y - panelHeight / 2
+      let dir = 'left' // 矢印はパネルの左側（ホバー位置を指す）
+
+      // 右に収まらない場合: 左横に配置
+      if (x + panelWidth > window.innerWidth - MARGIN) {
+        x = position.x - panelWidth - ARROW_SIZE - GAP
+        dir = 'right' // 矢印はパネルの右側
       }
 
-      // Check bottom boundary
-      if (y + rect.height > window.innerHeight - MARGIN) {
-        y = position.y - rect.height - OFFSET_Y
-      }
-
-      // Check left boundary after right adjustment
+      // 左にも収まらない場合: 下に配置
       if (x < MARGIN) {
-        x = position.x + OFFSET_X
-        if (x + rect.width > window.innerWidth - MARGIN) {
-          x = Math.max(MARGIN, window.innerWidth - rect.width - MARGIN)
-        }
+        x = Math.max(MARGIN, position.x - panelWidth / 2)
+        y = position.y + ARROW_SIZE + GAP
+        dir = 'top' // 矢印はパネルの上側
       }
 
-      // Check top boundary after bottom adjustment
+      // 上下の画面外補正
       if (y < MARGIN) {
-        y = position.y + OFFSET_Y
-        if (y + rect.height > window.innerHeight - MARGIN) {
-          y = Math.max(MARGIN, window.innerHeight - rect.height - MARGIN)
-        }
+        y = MARGIN
+      } else if (y + panelHeight > window.innerHeight - MARGIN) {
+        y = window.innerHeight - panelHeight - MARGIN
       }
 
+      setArrowDir(dir)
       setAdjustedPosition({ x, y })
+      setIsPositioned(true)
     }
   }, [position, isVisible])
 
-  if (!isVisible || !data) return null
+  if (!isVisible || !data || !position) return null
 
   return (
     <div
@@ -92,9 +96,13 @@ export const MapTooltip = ({ isVisible, position, data, type, onClose }) => {
         position: 'fixed',
         left: `${adjustedPosition.x}px`,
         top: `${adjustedPosition.y}px`,
-        zIndex: 9999
+        zIndex: 9999,
+        opacity: isPositioned ? 1 : 0
       }}
     >
+      {arrowDir !== 'none' && (
+        <div className={`${styles.arrow} ${styles[arrowDir]}`} />
+      )}
       <div className={styles.content}>
         {type === 'waypoint' && (
           <>

--- a/src/components/MapTooltip/MapTooltip.module.scss
+++ b/src/components/MapTooltip/MapTooltip.module.scss
@@ -13,6 +13,50 @@
   font-family: 'Inter', 'Noto Sans JP', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
 }
 
+// Arrow styles (CoordinateDisplay準拠)
+.arrow {
+  position: absolute;
+  width: 0;
+  height: 0;
+  border: 8px solid transparent;
+
+  // 矢印がパネル左側 → ホバー位置は左にある
+  &.left {
+    left: -16px;
+    top: 50%;
+    transform: translateY(-50%);
+    border-right-color: var(--tooltip-bg, rgba(30, 30, 30, 0.85));
+    border-left-width: 0;
+  }
+
+  // 矢印がパネル右側 → ホバー位置は右にある
+  &.right {
+    right: -16px;
+    top: 50%;
+    transform: translateY(-50%);
+    border-left-color: var(--tooltip-bg, rgba(30, 30, 30, 0.85));
+    border-right-width: 0;
+  }
+
+  // 矢印がパネル上側 → ホバー位置は上にある
+  &.top {
+    top: -16px;
+    left: 50%;
+    transform: translateX(-50%);
+    border-bottom-color: var(--tooltip-bg, rgba(30, 30, 30, 0.85));
+    border-top-width: 0;
+  }
+
+  // 矢印がパネル下側 → ホバー位置は下にある
+  &.bottom {
+    bottom: -16px;
+    left: 50%;
+    transform: translateX(-50%);
+    border-top-color: var(--tooltip-bg, rgba(30, 30, 30, 0.85));
+    border-bottom-width: 0;
+  }
+}
+
 @keyframes fadeIn {
   from {
     opacity: 0;

--- a/src/components/RouteOptimizer/RouteOptimizer.jsx
+++ b/src/components/RouteOptimizer/RouteOptimizer.jsx
@@ -169,6 +169,9 @@ const RouteOptimizer = ({
           <div className="route-optimizer__header-content">
             <Route size={20} />
             <h2>最適巡回ルートプランナー</h2>
+            <span className="route-optimizer__wip-badge" title="現在ベータ版・構想段階の機能です">
+              BETA · WIP
+            </span>
           </div>
           <div className="route-optimizer__header-actions">
             {step > 1 && (
@@ -210,6 +213,18 @@ const RouteOptimizer = ({
           <div className={`route-optimizer__step ${step >= 4 ? 'active' : ''}`}>
             <span className="route-optimizer__step-number">4</span>
             <span className="route-optimizer__step-label">結果</span>
+          </div>
+        </div>
+
+        {/* ベータ版の注意書き */}
+        <div className="route-optimizer__beta-notice">
+          <AlertTriangle size={16} />
+          <div>
+            <strong>ベータ版・アイデアベースの機能です</strong>
+            <p>
+              現在構想段階のため、実際の飛行計画としてそのまま使用しないでください。
+              同一エリア内の飛行のみ最適化対象となり、遠距離拠点（20km以上離れた拠点同士）は別フライトとして分離されます。
+            </p>
           </div>
         </div>
 
@@ -428,6 +443,16 @@ const RouteOptimizer = ({
                 <div className="route-optimizer__improvement">
                   <CheckCircle size={16} />
                   ルート距離を{optimizationResult.summary.improvement}%短縮しました
+                </div>
+              )}
+
+              {optimizationResult.summary.isMultiCluster && (
+                <div className="route-optimizer__cluster-notice">
+                  <AlertTriangle size={16} />
+                  <span>
+                    遠距離に分散した{optimizationResult.summary.clusterCount}つのエリアを検出しました。
+                    各エリアを独立したフライトとして最適化しています（エリア間の直線飛行は行いません）。
+                  </span>
                 </div>
               )}
 

--- a/src/components/RouteOptimizer/RouteOptimizer.scss
+++ b/src/components/RouteOptimizer/RouteOptimizer.scss
@@ -59,6 +59,72 @@
     }
   }
 
+  &__wip-badge {
+    display: inline-flex;
+    align-items: center;
+    padding: 3px 8px;
+    background: linear-gradient(135deg, #f59e0b, #d97706);
+    color: #fff;
+    font-size: 10px;
+    font-weight: 700;
+    letter-spacing: 0.5px;
+    border-radius: 4px;
+    border: 1px solid rgba(255, 255, 255, 0.3);
+    text-transform: uppercase;
+    white-space: nowrap;
+    box-shadow: 0 1px 3px rgba(0, 0, 0, 0.2);
+  }
+
+  &__beta-notice {
+    display: flex;
+    align-items: flex-start;
+    gap: 10px;
+    padding: 12px 20px;
+    background: rgba(251, 191, 36, 0.1);
+    border-bottom: 1px solid rgba(251, 191, 36, 0.3);
+    color: var(--text-primary, #1f2937);
+
+    svg {
+      flex-shrink: 0;
+      color: #f59e0b;
+      margin-top: 2px;
+    }
+
+    strong {
+      display: block;
+      font-size: 13px;
+      color: #d97706;
+      margin-bottom: 4px;
+    }
+
+    p {
+      margin: 0;
+      font-size: 12px;
+      line-height: 1.5;
+      color: var(--text-secondary, #6b7280);
+    }
+  }
+
+  &__cluster-notice {
+    display: flex;
+    align-items: flex-start;
+    gap: 10px;
+    padding: 10px 14px;
+    margin: 12px 0;
+    background: rgba(245, 158, 11, 0.1);
+    border: 1px solid rgba(245, 158, 11, 0.3);
+    border-radius: 6px;
+    color: var(--text-primary, #1f2937);
+    font-size: 12px;
+    line-height: 1.5;
+
+    svg {
+      flex-shrink: 0;
+      color: #f59e0b;
+      margin-top: 1px;
+    }
+  }
+
   &__reset-btn,
   &__close-btn {
     background: rgba(255, 255, 255, 0.2);

--- a/src/components/WaypointList/WaypointList.jsx
+++ b/src/components/WaypointList/WaypointList.jsx
@@ -142,7 +142,7 @@ const WaypointList = ({
             className={`${styles.iconButton} ${styles.routeButton}`}
             onClick={onOpenRouteOptimizer}
             disabled={waypoints.length < 2}
-            data-tooltip="ルート最適化"
+            data-tooltip="ルート最適化 (ベータ版)"
             data-tooltip-pos="bottom"
           >
             <Route size={16} />

--- a/src/services/didService.js
+++ b/src/services/didService.js
@@ -176,13 +176,24 @@ const checkPointInDIDGeoJSON = (geojson, lat, lng) => {
         console.log(`[DID] DETECTED: lat=${lat.toFixed(6)}, lng=${lng.toFixed(6)} -> ${areaName}`);
       }
 
+      const props = feature.properties || {};
+      const population = props.JINKO || 0;
+      const menseki = props.MENSEKI || 0;
+      const density = menseki > 0 ? population / menseki : 0;
+
       return {
         isDID: true,
         area: areaName,
         certainty: 'confirmed',
         source: 'local/R02',
         description: `${areaName}のDID内`,
-        centroid
+        centroid,
+        // ツールチップ用詳細データ
+        population,
+        menseki,
+        density,
+        kenCode: props.KEN || '',
+        cityCode: props.CITY || '',
       };
     }
   }
@@ -219,7 +230,8 @@ export const checkDIDArea = async (lat, lng) => {
       if (geojson) {
         const result = checkPointInDIDGeoJSON(geojson, lat, lng);
         if (result) {
-          // Found in DID - return immediately
+          // Found in DID - return immediately with prefecture name
+          result.prefectureName = prefecture.nameJa;
           if (import.meta.env.DEV) {
             console.log(`[DID] ✓ DID検出: ${result.area} (${prefecture.nameJa})`);
           }

--- a/src/services/routeOptimizer.js
+++ b/src/services/routeOptimizer.js
@@ -438,6 +438,18 @@ export const optimizeRoute = async (waypoints, options = {}) => {
   // 全クラスタのorderedWaypointsをフラット化
   const orderedWaypoints = clusterResults.flatMap((c) => c.waypoints)
 
+  // クラスタ単位でoriginal/optimized距離を集計（improvement計算用）
+  // 全体距離行列で計算するとクラスタ間ジャンプが含まれてしまうため、
+  // 各クラスタ内で個別に計算して合算する
+  let originalDistanceSum = 0
+  let optimizedDistanceSum = 0
+  for (const cluster of clusterResults) {
+    const baseIndices = cluster.waypoints.map((_, i) => i)
+    // 元順序: クラスタ内Waypointの元配列順序（クラスタリング前の順を保持）
+    originalDistanceSum += calculateRouteDistance(baseIndices, cluster.distanceMatrix)
+    optimizedDistanceSum += calculateRouteDistance(cluster.indices, cluster.distanceMatrix)
+  }
+
   // 6. バッテリー制約でルート分割
   // 複数クラスタの場合、各クラスタを独立したフライトとして扱う
   let flights = []
@@ -472,11 +484,10 @@ export const optimizeRoute = async (waypoints, options = {}) => {
     flights.push(...clusterFlights)
   }
 
-  // 代表距離行列（全体サマリー計算用）
-  const distanceMatrix = buildDistanceMatrix(waypoints)
-  const routeIndices = orderedWaypoints.map((wp) =>
-    waypoints.findIndex((orig) => orig.id === wp.id)
-  )
+  // routeIndices: orderedWaypoints の元waypoints配列内インデックス
+  // O(n) で構築（findIndex の O(n²) を回避）
+  const idToIndex = new Map(waypoints.map((wp, i) => [wp.id, i]))
+  const routeIndices = orderedWaypoints.map((wp) => idToIndex.get(wp.id) ?? -1)
 
   // 7. 各フライトに追加情報を付与
   const processedFlights = flights.map((flight, idx) => ({
@@ -506,14 +517,9 @@ export const optimizeRoute = async (waypoints, options = {}) => {
   const totalDistance = processedFlights.reduce((sum, f) => sum + f.totalDistance, 0);
   const totalTime = processedFlights.reduce((sum, f) => sum + f.estimatedTime, 0);
 
-  // 改善率を計算（元のインデックス順との比較）
-  const originalDistance = calculateRouteDistance(
-    waypoints.map((_, i) => i),
-    distanceMatrix
-  );
-  const optimizedDistance = calculateRouteDistance(routeIndices, distanceMatrix);
-  const improvement = originalDistance > 0
-    ? Math.round((1 - optimizedDistance / originalDistance) * 100)
+  // 改善率を計算（クラスタ内の合算で算出 — 複数クラスタでも正確な値）
+  const improvement = originalDistanceSum > 0
+    ? Math.round((1 - optimizedDistanceSum / originalDistanceSum) * 100)
     : 0;
 
   return {

--- a/src/services/routeOptimizer.js
+++ b/src/services/routeOptimizer.js
@@ -18,6 +18,55 @@ const getDistance = (point1, point2) => {
 };
 
 /**
+ * 拠点クラスタリング（同一エリア内のWaypointをグループ化）
+ * 距離が閾値以上離れたWaypoint群は別クラスタとして分離する。
+ * これにより、例えば北海道と大阪のような遠距離拠点を一直線でつなぐ
+ * 異常なルートを防止する。
+ *
+ * @param {Array} waypoints - ウェイポイント配列
+ * @param {number} thresholdMeters - クラスタ分離の閾値（メートル、デフォルト20km）
+ * @returns {Array<Array>} クラスタごとのウェイポイント配列
+ */
+export const clusterWaypointsByProximity = (waypoints, thresholdMeters = 20000) => {
+  if (!waypoints || waypoints.length === 0) return []
+  if (waypoints.length === 1) return [waypoints]
+
+  // Union-Find でクラスタリング
+  const n = waypoints.length
+  const parent = Array(n).fill(0).map((_, i) => i)
+  const find = (x) => {
+    while (parent[x] !== x) {
+      parent[x] = parent[parent[x]]
+      x = parent[x]
+    }
+    return x
+  }
+  const union = (a, b) => {
+    const ra = find(a)
+    const rb = find(b)
+    if (ra !== rb) parent[ra] = rb
+  }
+
+  for (let i = 0; i < n; i++) {
+    for (let j = i + 1; j < n; j++) {
+      if (getDistance(waypoints[i], waypoints[j]) <= thresholdMeters) {
+        union(i, j)
+      }
+    }
+  }
+
+  // クラスタごとにグルーピング
+  const clusters = new Map()
+  for (let i = 0; i < n; i++) {
+    const root = find(i)
+    if (!clusters.has(root)) clusters.set(root, [])
+    clusters.get(root).push(waypoints[i])
+  }
+
+  return Array.from(clusters.values())
+}
+
+/**
  * 距離行列を構築
  * @param {Array} waypoints - ウェイポイント配列
  * @returns {Array<Array<number>>} 距離行列
@@ -348,50 +397,86 @@ export const optimizeRoute = async (waypoints, options = {}) => {
     };
   }
 
-  // 1. 最適出発点を計算
+  // 0. 拠点クラスタリング（同一エリア内のWaypointをグループ化）
+  // 遠距離拠点を一直線でつなぐ異常なルートを防止するため、
+  // 20km以上離れたWaypoint群は別クラスタとして分離する。
+  const CLUSTER_THRESHOLD_METERS = 20000
+  const clusters = clusterWaypointsByProximity(waypoints, CLUSTER_THRESHOLD_METERS)
+  const isMultiCluster = clusters.length > 1
+
+  // 1. 最適出発点を計算（全Waypoint基準、後方互換性のため）
   const optimalStart = findOptimalStartPoint(waypoints);
   const effectiveHomePoint = homePoint || {
     lat: optimalStart.lat,
     lng: optimalStart.lng,
   };
 
-  // 2. 距離行列を構築
-  const distanceMatrix = buildDistanceMatrix(waypoints);
+  // 2-5. 各クラスタごとに最適化（TSP + 順序付け）
+  let globalOrder = 0
+  const clusterResults = clusters.map((clusterWaypoints) => {
+    const clusterMatrix = buildDistanceMatrix(clusterWaypoints)
+    const clusterStart = findOptimalStartPoint(clusterWaypoints)
+    let clusterIndices = nearestNeighborTSP(clusterWaypoints, clusterStart.index, clusterMatrix)
 
-  // 3. TSPで最適順序を計算
-  let routeIndices = nearestNeighborTSP(waypoints, optimalStart.index, distanceMatrix);
+    if (algorithm === '2-opt') {
+      clusterIndices = twoOptImprove(clusterIndices, clusterMatrix)
+    }
 
-  // 4. 2-opt改善（オプション）
-  if (algorithm === '2-opt') {
-    routeIndices = twoOptImprove(routeIndices, distanceMatrix);
-  }
+    const ordered = clusterIndices.map((idx) => ({
+      ...clusterWaypoints[idx],
+      optimizedOrder: ++globalOrder,
+    }))
 
-  // 5. インデックスからウェイポイントに変換
-  const orderedWaypoints = routeIndices.map((idx, order) => ({
-    ...waypoints[idx],
-    optimizedOrder: order + 1,
-  }));
+    return {
+      waypoints: ordered,
+      distanceMatrix: clusterMatrix,
+      indices: clusterIndices,
+      startPoint: clusterStart,
+    }
+  })
+
+  // 全クラスタのorderedWaypointsをフラット化
+  const orderedWaypoints = clusterResults.flatMap((c) => c.waypoints)
 
   // 6. バッテリー制約でルート分割
-  let flights;
-  if (autoSplit) {
-    flights = splitRouteByBattery(orderedWaypoints, droneSpec, effectiveHomePoint);
-  } else {
-    // 分割なし（単一フライト）
-    let totalDist = 0;
-    const wps = orderedWaypoints.map((wp, idx) => {
-      const prev = idx === 0 ? effectiveHomePoint : orderedWaypoints[idx - 1];
-      const segDist = getDistance(prev, wp);
-      totalDist += segDist;
-      return { ...wp, segmentDistance: segDist };
-    });
-    const returnDist = getDistance(orderedWaypoints[orderedWaypoints.length - 1], effectiveHomePoint);
-    flights = [{
-      waypoints: wps,
-      totalDistance: totalDist + returnDist,
-      returnDistance: returnDist,
-    }];
+  // 複数クラスタの場合、各クラスタを独立したフライトとして扱う
+  let flights = []
+  for (const cluster of clusterResults) {
+    // 各クラスタ内のHome Pointは、クラスタ内の最適出発点を使用
+    const clusterHomePoint = isMultiCluster
+      ? { lat: cluster.startPoint.lat, lng: cluster.startPoint.lng }
+      : effectiveHomePoint
+
+    let clusterFlights
+    if (autoSplit) {
+      clusterFlights = splitRouteByBattery(cluster.waypoints, droneSpec, clusterHomePoint)
+    } else {
+      let totalDist = 0
+      const wps = cluster.waypoints.map((wp, idx) => {
+        const prev = idx === 0 ? clusterHomePoint : cluster.waypoints[idx - 1]
+        const segDist = getDistance(prev, wp)
+        totalDist += segDist
+        return { ...wp, segmentDistance: segDist }
+      })
+      const returnDist = getDistance(
+        cluster.waypoints[cluster.waypoints.length - 1],
+        clusterHomePoint
+      )
+      clusterFlights = [{
+        waypoints: wps,
+        totalDistance: totalDist + returnDist,
+        returnDistance: returnDist,
+        clusterHomePoint,
+      }]
+    }
+    flights.push(...clusterFlights)
   }
+
+  // 代表距離行列（全体サマリー計算用）
+  const distanceMatrix = buildDistanceMatrix(waypoints)
+  const routeIndices = orderedWaypoints.map((wp) =>
+    waypoints.findIndex((orig) => orig.id === wp.id)
+  )
 
   // 7. 各フライトに追加情報を付与
   const processedFlights = flights.map((flight, idx) => ({
@@ -452,6 +537,8 @@ export const optimizeRoute = async (waypoints, options = {}) => {
       batteryChanges: processedFlights.length - 1,
       warnings: restrictions.filter(r => r.severity === 'high' || r.severity === 'critical').length,
       algorithm,
+      clusterCount: clusters.length,
+      isMultiCluster,
     },
     orderedWaypoints,
   };

--- a/src/services/routeOptimizer.js
+++ b/src/services/routeOptimizer.js
@@ -484,11 +484,6 @@ export const optimizeRoute = async (waypoints, options = {}) => {
     flights.push(...clusterFlights)
   }
 
-  // routeIndices: orderedWaypoints の元waypoints配列内インデックス
-  // O(n) で構築（findIndex の O(n²) を回避）
-  const idToIndex = new Map(waypoints.map((wp, i) => [wp.id, i]))
-  const routeIndices = orderedWaypoints.map((wp) => idToIndex.get(wp.id) ?? -1)
-
   // 7. 各フライトに追加情報を付与
   const processedFlights = flights.map((flight, idx) => ({
     flightNumber: idx + 1,

--- a/src/services/settingsService.js
+++ b/src/services/settingsService.js
@@ -21,6 +21,10 @@ const DEFAULT_SETTINGS = {
   prohibitedAvoidanceMargin: 300,
   // Waypoint番号体系: 'global'(全体連番) | 'perPolygon'(ポリゴンごと1から)
   waypointNumberingMode: 'global',
+  // 地図ホバーツールチップ表示（DID/施設レイヤー）
+  showMapHoverTooltip: false,
+  // ツールチップ自動消去（オフならホバー継続中は表示し続ける）
+  mapHoverTooltipAutoFade: true,
 };
 
 /**


### PR DESCRIPTION
## Summary

DIDinJapan準拠の地図ホバーツールチップ機能を追加し、ルート最適化のベータ版表示と遠距離クラスタ分離を実装しました。

## 主な変更内容

### 1. 地図ホバーツールチップ機能 (DIDinJapan準拠)
- DID（人口集中地区）ホバーで市区町村名・人口・面積・人口密度・コードを表示
- 全レイヤー対応: DID + 施設レイヤー（原発・県庁・警察・刑務所・自衛隊・空港・ヘリポート・緊急空域・RemoteID・有人機・レッド/イエローゾーン）
- `maplibregl.Popup` + ガラスモーフィズムスタイル（ダーク/ライト対応）
- mousemove → RAFスロットリング → 300msデバウンス → `checkDIDArea()` で軽量動作
- 設定UIを左サイドバー（住所検索の下）に「地図操作」アコーディオンとして配置
- `[T]`キーでON/OFFトグル、「自動で消える」オプション付き
- デフォルトOFF
- 設定永続化は `settingsService` 経由

### 2. MapTooltip 矢印自動方向決定
- ホバー位置に応じて右→左→下とフォールバック配置
- CoordinateDisplayと同じロジック・スタイル
- 初回チラつき防止 (`isPositioned` ガード)
- ESCキーで閉じる
- ダーク/ライトテーマ対応（CSS変数 `--tooltip-bg` 経由）

### 3. ルート最適化の WIP 表示と遠距離分離
- 「BETA · WIP」バッジと注意書きをルートプランナーに表示
- 拠点クラスタリング（20km閾値、Union-Find）を実装
- 遠距離拠点（北海道↔大阪など）を別フライトとして分離し、一直線でつなぐ異常ルートを防止
- 複数クラスタ検出時に結果画面で警告通知

### 4. コードレビュー指摘の修正
- improvement計算をクラスタ単位で集計（誤った%表示を修正）
- routeIndices構築をMap化してO(n)に最適化
- アクセシビリティ: `<button>` + `aria-expanded` / `aria-controls`
- async race対策: `await` 後のトグル状態再チェック
- XSS対策: HTMLエスケープヘルパー追加
- drawMode/editingPolygon遷移時のクリーンアップ追加

## Test plan

- [ ] DIDレイヤーをONにし、左サイドバーの「地図操作」から「ツールチップ」を有効化
- [ ] DIDエリアでホバーすると Popup が表示される（市区町村名・人口・面積・密度・コード）
- [ ] 施設レイヤー（原発・県庁等）でホバーすると施設情報 Popup が表示される
- [ ] `[T]` キーでON/OFFが切り替わる
- [ ] 「自動で消える」OFF時はホバー継続中表示し続ける
- [ ] WP/ポリゴンホバー時に MapTooltip が矢印付きで表示される
- [ ] ホバー位置によって矢印方向が右→左→下と切り替わる
- [ ] ルートプランナーを開くと「BETA · WIP」バッジと注意書きが表示される
- [ ] 北海道と大阪の遠距離Waypointで最適化すると、別フライトに分離される
- [ ] 描画モード/編集モード中はツールチップが表示されない
- [ ] ダーク/ライトテーマ切り替えで矢印・Popup色が追従

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新機能**
  * ホバーでDID（特定用途地域）/施設情報を表示するマップツールチップを追加。サイドバーに「地図クイックコントロール」で表示・自動消去を切替可能。
  * ルート最適化で分散エリアを検出し、各エリアを独立して最適化（ベータ表示・注意文あり）。

* **スタイル**
  * ツールチップの矢印表示・配置ロジックを改善。ダーク/ライトテーマ向けのポップアップスタイルを追加。

* **その他**
  * ツールチップ関連の既定設定を追加し、キーボードショートカットでの切替に対応。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->