### PR TITLE
fix: サイドバー開閉状態の永続化 + ダブルスクロール解消

### DIFF
--- a/src/App.scss
+++ b/src/App.scss
@@ -305,6 +305,7 @@ body {
 }
 
 .search-section {
+  flex-shrink: 0;
   border-bottom: 1px solid var(--color-border);
 
   &.collapsed {
@@ -353,6 +354,7 @@ body {
 
 // Map Quick Controls - サイドバー内の地図クイックコントローラー
 .map-quick-controls {
+  flex-shrink: 0;
   border-bottom: 1px solid var(--color-border);
   background: var(--color-bg-secondary);
 
@@ -653,6 +655,7 @@ body {
 }
 
 .panel-tabs {
+  flex-shrink: 0;
   display: flex;
   border-bottom: 1px solid var(--color-border);
 }

--- a/src/components/MainLayout/MainLayout.jsx
+++ b/src/components/MainLayout/MainLayout.jsx
@@ -1,6 +1,6 @@
 import { useState, useEffect, useCallback, useRef, useMemo } from 'react'
 import { ChevronDown, Search, Undo2, Redo2, Map as MapIcon, Layers, Settings, Sun, Moon, Menu, Route, Maximize2, Minimize2, X, Download, Box, Rotate3D, Crosshair, Satellite } from 'lucide-react'
-import { getSetting, setSetting, isDIDAvoidanceModeEnabled, getWaypointNumberingMode } from '../../services/settingsService'
+import { getSetting, saveSettings, isDIDAvoidanceModeEnabled, getWaypointNumberingMode } from '../../services/settingsService'
 import { MAP_STYLES, CROSSHAIR_DESIGNS, CROSSHAIR_COLORS, COORDINATE_FORMATS } from '../Map/mapConstants'
 import { getDetailedCollisionResults, getDetailedCollisionResultsWithRestrictionSurfaces, checkWaypointsRestrictionSurfaces, checkAllWaypointsDID, checkAllPolygonsCollision } from '../../services/riskService'
 import { preloadDIDDataForCoordinates, isAllDIDCacheReady } from '../../services/didService'
@@ -153,33 +153,47 @@ function MainLayout() {
   const [activePanel, setActivePanel] = useState('polygons') // 'polygons' | 'waypoints'
   const [panelHeight, setPanelHeight] = useState(null) // null = auto
   // サイドバーセクションの開閉状態を localStorage に永続化
+  // デフォルト値は settingsService.js の DEFAULT_SETTINGS で管理
   const [isSearchExpanded, setIsSearchExpanded] = useState(
-    () => getSetting('sidebarSearchExpanded') ?? true
+    () => getSetting('sidebarSearchExpanded')
   )
   const [isMapQuickControlsExpanded, setIsMapQuickControlsExpanded] = useState(
-    () => getSetting('sidebarMapControlsExpanded') ?? true
+    () => getSetting('sidebarMapControlsExpanded')
   )
 
+  // 初回マウント時の不要な書き込みを回避するためのフラグ
+  const sidebarSettingsInitializedRef = useRef(false)
   useEffect(() => {
-    setSetting('sidebarSearchExpanded', isSearchExpanded)
-  }, [isSearchExpanded])
-
-  useEffect(() => {
-    setSetting('sidebarMapControlsExpanded', isMapQuickControlsExpanded)
-  }, [isMapQuickControlsExpanded])
+    // 初回レンダリング時は state を localStorage から読み込んだ直後なので
+    // 書き戻し不要（I/O 削減）
+    if (!sidebarSettingsInitializedRef.current) {
+      sidebarSettingsInitializedRef.current = true
+      return
+    }
+    // 両方の設定をまとめて保存（個別に保存するとそれぞれで全体書き込みが発生するため）
+    saveSettings({
+      sidebarSearchExpanded: isSearchExpanded,
+      sidebarMapControlsExpanded: isMapQuickControlsExpanded,
+    })
+  }, [isSearchExpanded, isMapQuickControlsExpanded])
 
   // Map quick controls state (sidebar に表示、デフォルトOFF)
   // settingsService 経由で永続化
   const [showDIDTooltip, setShowDIDTooltip] = useState(() => getSetting('showMapHoverTooltip') ?? false)
   const [didTooltipAutoFade, setDidTooltipAutoFade] = useState(() => getSetting('mapHoverTooltipAutoFade') ?? true)
 
+  // ツールチップ設定もまとめて保存 + 初回スキップで不要な I/O 回避
+  const tooltipSettingsInitializedRef = useRef(false)
   useEffect(() => {
-    setSetting('showMapHoverTooltip', showDIDTooltip)
-  }, [showDIDTooltip])
-
-  useEffect(() => {
-    setSetting('mapHoverTooltipAutoFade', didTooltipAutoFade)
-  }, [didTooltipAutoFade])
+    if (!tooltipSettingsInitializedRef.current) {
+      tooltipSettingsInitializedRef.current = true
+      return
+    }
+    saveSettings({
+      showMapHoverTooltip: showDIDTooltip,
+      mapHoverTooltipAutoFade: didTooltipAutoFade,
+    })
+  }, [showDIDTooltip, didTooltipAutoFade])
 
   // Map側から同期される制御API（3D、Crosshair、MapStyle）
   // Map.jsx内部のhook状態をsidebarから操作するためのブリッジ

--- a/src/components/MainLayout/MainLayout.jsx
+++ b/src/components/MainLayout/MainLayout.jsx
@@ -152,8 +152,21 @@ function MainLayout() {
   const [drawMode, setDrawMode] = useState(false)
   const [activePanel, setActivePanel] = useState('polygons') // 'polygons' | 'waypoints'
   const [panelHeight, setPanelHeight] = useState(null) // null = auto
-  const [isSearchExpanded, setIsSearchExpanded] = useState(true)
-  const [isMapQuickControlsExpanded, setIsMapQuickControlsExpanded] = useState(true)
+  // サイドバーセクションの開閉状態を localStorage に永続化
+  const [isSearchExpanded, setIsSearchExpanded] = useState(
+    () => getSetting('sidebarSearchExpanded') ?? true
+  )
+  const [isMapQuickControlsExpanded, setIsMapQuickControlsExpanded] = useState(
+    () => getSetting('sidebarMapControlsExpanded') ?? true
+  )
+
+  useEffect(() => {
+    setSetting('sidebarSearchExpanded', isSearchExpanded)
+  }, [isSearchExpanded])
+
+  useEffect(() => {
+    setSetting('sidebarMapControlsExpanded', isMapQuickControlsExpanded)
+  }, [isMapQuickControlsExpanded])
 
   // Map quick controls state (sidebar に表示、デフォルトOFF)
   // settingsService 経由で永続化

--- a/src/components/PolygonList/PolygonList.module.scss
+++ b/src/components/PolygonList/PolygonList.module.scss
@@ -103,7 +103,7 @@
 
 .list {
   flex: 1;
-  overflow-y: auto;
+  // overflow-y は親 .panel-content で管理（ダブルスクロール回避）
   margin: 0;
   padding: 0;
   list-style: none;

--- a/src/components/WaypointList/WaypointList.module.scss
+++ b/src/components/WaypointList/WaypointList.module.scss
@@ -188,7 +188,7 @@
 
 .groups {
   flex: 1;
-  overflow-y: auto;
+  // overflow-y は親 .panel-content で管理（ダブルスクロール回避）
 }
 
 .group {

--- a/src/services/settingsService.js
+++ b/src/services/settingsService.js
@@ -25,6 +25,10 @@ const DEFAULT_SETTINGS = {
   showMapHoverTooltip: false,
   // ツールチップ自動消去（オフならホバー継続中は表示し続ける）
   mapHoverTooltipAutoFade: true,
+  // サイドバー「住所検索」セクションの開閉状態（永続化）
+  sidebarSearchExpanded: true,
+  // サイドバー「地図操作」セクションの開閉状態（永続化）
+  sidebarMapControlsExpanded: true,
 };
 
 /**


### PR DESCRIPTION
## Problem

### 1. 開閉状態が保持されない
「住所検索」「地図操作」セクションの開閉状態がリロードするたびにリセットされ、ユーザーが閉じていても強制的に展開状態になる。

### 2. ダブルスクロール
サイドバー内で縦スクロールバーが2本表示される。

## Root Cause

### ダブルスクロールの原因
\`.panel-content\` (App.scss:704) と、その内部の \`.list\` (PolygonList) / \`.groups\` (WaypointList) の両方に \`overflow-y: auto\` が設定されており、二重のスクロールコンテナが作られていた。

## Fix

### 永続化
- \`settingsService.js\` に \`sidebarSearchExpanded\` と \`sidebarMapControlsExpanded\` を追加
- MainLayout で \`getSetting\` / \`setSetting\` 経由で状態を永続化

### ダブルスクロール解消
- \`PolygonList.module.scss\` の \`.list\` から \`overflow-y: auto\` を削除
- \`WaypointList.module.scss\` の \`.groups\` から \`overflow-y: auto\` を削除
- \`.search-section\` / \`.map-quick-controls\` / \`.panel-tabs\` に \`flex-shrink: 0\` を追加
- スクロールは常に \`.panel-content\` の一箇所のみに統一

## Test plan

- [ ] 住所検索セクションを閉じる → リロード → 閉じた状態が維持される
- [ ] 地図操作セクションを閉じる → リロード → 閉じた状態が維持される
- [ ] ポリゴン一覧が多数あってもスクロールバーが1本のみ
- [ ] Waypoint一覧が多数あってもスクロールバーが1本のみ
- [ ] 地図操作の全セクションを展開しても \`panel-content\` のみがスクロール

🤖 Generated with [Claude Code](https://claude.com/claude-code)