### PR TITLE
fix: エリア生成パネルの誤操作を招く構造を改善

### DIFF
--- a/src/components/SearchForm/SearchForm.jsx
+++ b/src/components/SearchForm/SearchForm.jsx
@@ -24,6 +24,7 @@ const SearchForm = ({ onSearch, onSelect, onGeneratePolygon }) => {
   const [isPanelExpanded, setIsPanelExpanded] = useState(true)
   const inputRef = useRef(null)
   const suggestionsRef = useRef(null)
+  const isGeneratingRef = useRef(false)
 
   const debouncedSearch = useMemo(
     () =>
@@ -108,12 +109,19 @@ const SearchForm = ({ onSearch, onSelect, onGeneratePolygon }) => {
   }
 
   const handleGeneratePolygon = () => {
-    if (lastSearchResult && onGeneratePolygon) {
-      const options = useCustomSize
-        ? { customRadius, shape: selectedShape, waypointCount }
-        : { size: selectedSize, shape: selectedShape, waypointCount }
-      onGeneratePolygon(lastSearchResult, options)
-    }
+    if (!lastSearchResult || !onGeneratePolygon) return
+    if (isGeneratingRef.current) return
+    isGeneratingRef.current = true
+    const options = useCustomSize
+      ? { useCustomSize: true, customRadius, shape: selectedShape, waypointCount }
+      : { size: selectedSize, shape: selectedShape, waypointCount }
+    onGeneratePolygon(lastSearchResult, options)
+    // 生成完了後はパネルを閉じて検索欄もクリアする。
+    // 開いたままだと「押しても見た目が変わらない」ため、
+    // ユーザーが連打して意図せず複数生成してしまう誤操作を誘発していた。
+    setQuery('')
+    setLastSearchResult(null)
+    isGeneratingRef.current = false
   }
 
   const handleRadiusChange = (e) => {
@@ -266,6 +274,7 @@ const SearchForm = ({ onSearch, onSelect, onGeneratePolygon }) => {
                       <button
                         key={option.value}
                         type="button"
+                        disabled={useCustomSize}
                         className={`${styles.shapeButton} ${
                           !useCustomSize && selectedSize === option.value
                             ? styles.active
@@ -294,7 +303,11 @@ const SearchForm = ({ onSearch, onSelect, onGeneratePolygon }) => {
                   カスタムサイズを使用
                 </label>
                 <div className={styles.customSizeFields}>
-                  <div className={styles.customRadius}>
+                  <div
+                    className={`${styles.customRadius} ${
+                      !useCustomSize ? styles.disabledField : ''
+                    }`}
+                  >
                     <label>半径: {customRadius}m</label>
                     <input
                       type="range"
@@ -302,6 +315,7 @@ const SearchForm = ({ onSearch, onSelect, onGeneratePolygon }) => {
                       max="300"
                       step="10"
                       value={customRadius}
+                      disabled={!useCustomSize}
                       onChange={handleRadiusChange}
                     />
                   </div>

--- a/src/components/SearchForm/SearchForm.module.scss
+++ b/src/components/SearchForm/SearchForm.module.scss
@@ -137,6 +137,11 @@
     border-color: var(--color-primary);
     color: #fff;
   }
+
+  &:disabled {
+    opacity: 0.4;
+    cursor: not-allowed;
+  }
 }
 
 .customSizeControls {
@@ -164,6 +169,14 @@
   input[type='number'] {
     width: 70px;
     padding: 4px;
+  }
+}
+
+.disabledField {
+  opacity: 0.4;
+
+  input[type='range'] {
+    cursor: not-allowed;
   }
 }
 

--- a/src/components/SearchForm/SearchForm.test.jsx
+++ b/src/components/SearchForm/SearchForm.test.jsx
@@ -1,0 +1,110 @@
+/**
+ * SearchForm テスト
+ *
+ * 「エリアを生成」パネルの誤操作を招く構造の回帰テスト:
+ * - 生成後にパネルが閉じること（連打による意図しない複数生成を防止）
+ * - カスタムサイズとプリセットサイズが同時に有効な状態にならないこと
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, fireEvent, waitFor } from '@testing-library/react'
+import SearchForm from './SearchForm'
+import { searchAddress } from '../../services/geocoding'
+
+vi.mock('../../services/geocoding', async () => {
+  const actual = await vi.importActual('../../services/geocoding')
+  return {
+    ...actual,
+    searchAddress: vi.fn(),
+  }
+})
+
+const mockSuggestion = {
+  displayName: '中川, 北葛飾郡, 埼玉県, 日本',
+  lat: 36.05,
+  lng: 139.75,
+  boundingBox: [35.9, 36.2, 139.6, 139.9],
+}
+
+const selectSuggestion = async () => {
+  searchAddress.mockResolvedValue([mockSuggestion])
+  fireEvent.change(screen.getByPlaceholderText(/住所・建物名を検索/), {
+    target: { value: '中川' },
+  })
+  await waitFor(() => expect(searchAddress).toHaveBeenCalled())
+  const item = await screen.findByText('中川')
+  fireEvent.click(item)
+}
+
+describe('SearchForm', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('候補を選択すると「エリアを生成」パネルが開く', async () => {
+    render(<SearchForm onGeneratePolygon={vi.fn()} />)
+    await selectSuggestion()
+    expect(screen.getByText('エリアを生成')).toBeInTheDocument()
+  })
+
+  it('「エリアを生成」を押すとパネルが閉じ、連打しても1回しか生成されない', async () => {
+    const onGeneratePolygon = vi.fn()
+    render(<SearchForm onGeneratePolygon={onGeneratePolygon} />)
+    await selectSuggestion()
+
+    const generateButton = screen.getByText('エリアを生成')
+    fireEvent.click(generateButton)
+
+    expect(onGeneratePolygon).toHaveBeenCalledTimes(1)
+    // パネルが閉じている（「エリアを生成」ボタンが消えている）ため、
+    // 同じ操作を繰り返しても新規呼び出しは発生しない
+    expect(screen.queryByText('エリアを生成')).not.toBeInTheDocument()
+  })
+
+  it('生成オプションにサイズ選択(size)が渡される', async () => {
+    const onGeneratePolygon = vi.fn()
+    render(<SearchForm onGeneratePolygon={onGeneratePolygon} />)
+    await selectSuggestion()
+    fireEvent.click(screen.getByText('エリアを生成'))
+
+    expect(onGeneratePolygon).toHaveBeenCalledWith(
+      mockSuggestion,
+      expect.objectContaining({ size: 'medium' })
+    )
+  })
+
+  it('カスタムサイズを有効にするとプリセットサイズボタンが無効化される', async () => {
+    render(<SearchForm onGeneratePolygon={vi.fn()} />)
+    await selectSuggestion()
+
+    fireEvent.click(screen.getByLabelText('カスタムサイズを使用'))
+
+    const presetButton = screen.getByText('中 (100m)').closest('button')
+    expect(presetButton).toBeDisabled()
+  })
+
+  it('カスタムサイズが無効な間は半径スライダーが無効化される', async () => {
+    render(<SearchForm onGeneratePolygon={vi.fn()} />)
+    await selectSuggestion()
+
+    const radiusSlider = screen.getByRole('slider')
+    expect(radiusSlider).toBeDisabled()
+
+    fireEvent.click(screen.getByLabelText('カスタムサイズを使用'))
+    expect(radiusSlider).not.toBeDisabled()
+  })
+
+  it('カスタムサイズ有効時は生成オプションにuseCustomSizeとcustomRadiusが渡る', async () => {
+    const onGeneratePolygon = vi.fn()
+    render(<SearchForm onGeneratePolygon={onGeneratePolygon} />)
+    await selectSuggestion()
+
+    fireEvent.click(screen.getByLabelText('カスタムサイズを使用'))
+    fireEvent.click(screen.getByText('エリアを生成'))
+
+    expect(onGeneratePolygon).toHaveBeenCalledWith(
+      mockSuggestion,
+      expect.objectContaining({ useCustomSize: true, customRadius: 100 })
+    )
+  })
+})


### PR DESCRIPTION
## Summary

「エリアを生成」実行後もパネルが開いたままで、押しても見た目が変わらないため連打による意図しない複数生成を誘発していた。生成完了後はパネルを閉じ検索欄もクリアするよう変更。

また、`useCustomSize` が生成オプションに渡っておらずカスタム半径指定が無視されるバグを修正。あわせて、プリセットサイズ(小/中/大/特大)とカスタム半径のどちらが有効か視覚的に分かりにくかったため、非選択側をdisabled化して排他関係を明確にした。

なお、当初発見した「boundingBoxがサイズ指定を無視する」バグは、PR #65で既に修正済みであることを確認済み（本PRでは重複対応していない）。

## 変更内容

- `handleGeneratePolygon` 実行後にパネルを閉じ検索欄をクリア（二重生成の温床を解消）
- `useCustomSize: true` を生成オプションに明示的に含めるよう修正
- プリセットサイズボタン⇔カスタム半径スライダーの排他関係をdisabled表示で明確化
- 連打による二重生成防止のrefガードを追加
- SearchFormのコンポーネントテストを6件追加

## Test plan

- [x] `npm run test:run` — 5ファイル83件全pass
- [x] `npm run lint` — 変更ファイル起因の新規エラーなし
- [x] `npm run build` — 成功
- [x] Playwright実機検証 — サイズ選択通りのポリゴンが1件だけ生成され、生成後にパネルが閉じることを確認

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **不具合修正**
  - エリア生成ボタンの連続クリックによる重複生成を防止しました。
  - 生成後に検索欄やパネルが確実にリセットされるよう改善しました。
- **UI改善**
  - カスタムサイズ使用時、プリセットサイズを選択できないようにしました。
  - カスタム半径スライダーの有効・無効状態を明確に表示し、適切に操作制御するようにしました。
- **テスト**
  - エリア生成、サイズ選択、カスタム半径の動作確認を追加しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->