### PR TITLE
fix: Shift+ドラッグでマップのパン操作が永久に無効化されるバグを修正

### DIFF
--- a/src/components/Map/hooks/useMapSelection.js
+++ b/src/components/Map/hooks/useMapSelection.js
@@ -77,6 +77,21 @@ export const useMapSelection = ({
     setSelectionBox(null)
   }, [selectionBox, waypoints, mapRef])
 
+  // フェイルセーフ: Shift+ドラッグ中にマウスがcanvas外に出た状態でボタンを
+  // 離すと、canvas要素にのみ紐づく onMouseUp が発火せず isSelecting が
+  // true のまま固着し、dragPan（!isSelecting）が永久に無効化されてしまう。
+  // isSelecting 中は window レベルでも mouseup を監視し、確実に解除する。
+  useEffect(() => {
+    if (!isSelecting) return
+
+    const handleGlobalMouseUp = () => {
+      handleSelectionEnd()
+    }
+
+    window.addEventListener('mouseup', handleGlobalMouseUp)
+    return () => window.removeEventListener('mouseup', handleGlobalMouseUp)
+  }, [isSelecting, handleSelectionEnd])
+
   // Keyboard handler for bulk delete (Delete/Backspace) and clear selection (Escape)
   useEffect(() => {
     const handleKeyDown = (e) => {

--- a/src/components/Map/hooks/useMapSelection.test.js
+++ b/src/components/Map/hooks/useMapSelection.test.js
@@ -1,0 +1,80 @@
+/**
+ * useMapSelection テスト
+ *
+ * Shift+ドラッグで選択ボックスを開始した後、マウスが canvas 外に出た
+ * 状態でボタンを離すと isSelecting が固着し、dragPan（!isSelecting）が
+ * 永久に無効化されるバグの回帰テスト。
+ */
+
+import { describe, it, expect, vi } from 'vitest'
+import { renderHook, act } from '@testing-library/react'
+import { useMapSelection } from './useMapSelection'
+
+const createMockMapRef = () => ({
+  current: {
+    getMap: () => ({
+      project: () => ({ x: 0, y: 0 }),
+    }),
+  },
+})
+
+const createShiftMouseEvent = (clientX, clientY) => ({
+  originalEvent: { shiftKey: true, clientX, clientY },
+  target: {
+    getCanvas: () => ({
+      getBoundingClientRect: () => ({ left: 0, top: 0 }),
+    }),
+  },
+})
+
+describe('useMapSelection', () => {
+  it('canvas内でonMouseUpを受け取ると選択状態を正しく終了する（正常系）', () => {
+    const mapRef = createMockMapRef()
+    const { result } = renderHook(() =>
+      useMapSelection({ mapRef, waypoints: [], drawMode: false, editingPolygon: null })
+    )
+
+    act(() => {
+      result.current.handlers.onMouseDown(createShiftMouseEvent(10, 10))
+    })
+    expect(result.current.isSelecting).toBe(true)
+
+    act(() => {
+      result.current.handlers.onMouseUp()
+    })
+    expect(result.current.isSelecting).toBe(false)
+    expect(result.current.selectionBox).toBeNull()
+  })
+
+  it('canvas外でマウスアップされ、canvasのonMouseUpが発火しなくても、windowのmouseupで選択状態が解除される（フェイルセーフ）', () => {
+    const mapRef = createMockMapRef()
+    const { result } = renderHook(() =>
+      useMapSelection({ mapRef, waypoints: [], drawMode: false, editingPolygon: null })
+    )
+
+    act(() => {
+      result.current.handlers.onMouseDown(createShiftMouseEvent(10, 10))
+    })
+    expect(result.current.isSelecting).toBe(true)
+
+    // canvas上のonMouseUpは発火しない状態を模し、windowのnative mouseupだけを発火させる
+    act(() => {
+      window.dispatchEvent(new MouseEvent('mouseup'))
+    })
+
+    expect(result.current.isSelecting).toBe(false)
+    expect(result.current.selectionBox).toBeNull()
+  })
+
+  it('選択中でない間はwindowのmouseupを購読しない（不要なリスナー登録を避ける）', () => {
+    const addSpy = vi.spyOn(window, 'addEventListener')
+    const mapRef = createMockMapRef()
+    renderHook(() =>
+      useMapSelection({ mapRef, waypoints: [], drawMode: false, editingPolygon: null })
+    )
+
+    const mouseupCalls = addSpy.mock.calls.filter(([type]) => type === 'mouseup')
+    expect(mouseupCalls.length).toBe(0)
+    addSpy.mockRestore()
+  })
+})


### PR DESCRIPTION
## Summary

ユーザー報告「掴んで移動、というごく普通のマップの移動ができなくなってる気がする」の根本原因を特定・修正しました。

## 原因

選択ボックス機能（Shift+ドラッグでWaypointを複数選択）中に、マウスがcanvas外に出た状態でボタンを離すと、canvas要素にのみ紐づく `onMouseUp` ハンドラが発火せず、`isSelecting` state が `true` のまま固着していました。

`Map.jsx` の `dragPan={!isSelecting}` はこの state で制御されているため、一度この状態になるとページをリロードするまで地図をドラッグでパンできなくなります。

Playwrightで `window.__debugIsSelecting` を直接読み取り、修正前後の実際の値を確認して原因を確定させました:

```
修正前: canvas外でmouseup直後 → {"isSelecting":true, "selectionBox":{...}}  ← 固着
修正後: canvas外でmouseup直後 → {"isSelecting":false, "selectionBox":null}  ← 正常に解除
```

## 修正内容

- `isSelecting` が `true` の間、`window` レベルでも `mouseup` を監視するフェイルセーフを追加
- canvas内での正常系（Shift+ドラッグで選択完了→通常パン）に影響がないことも実機確認済み
- 回帰テストを3件追加（正常系・フェイルセーフ・不要なリスナー登録がないことの確認）

## Test plan

- [x] `npm run test:run` — 6ファイル86件全pass
- [x] `npm run build` — 成功
- [x] Playwright実機検証 — canvas外でのShift+ドラッグ終了後もdragPanが正常に機能することを確認
- [x] 正常系（canvas内での選択完了）に回帰がないことを確認