### PR TITLE
fix: Enterキーでの検索でも「エリアを生成」パネルが表示されるよう修正

### DIFF
--- a/src/components/SearchForm/SearchForm.jsx
+++ b/src/components/SearchForm/SearchForm.jsx
@@ -60,18 +60,36 @@ const SearchForm = ({ onSearch, onSelect, onGeneratePolygon }) => {
     onSelect?.(suggestion)
   }
 
-  const handleSubmit = (e) => {
+  const handleSubmit = async (e) => {
     e.preventDefault()
     // IME変換中の場合は何もしない（日本語入力の候補確定を尊重）
     if (isComposing) return
     // e.nativeEvent.isComposing もチェック（一部ブラウザで compositionend 前に Enter が発火するため）
     if (e.nativeEvent?.isComposing) return
 
+    // 矢印キーで候補を選択済みならそれを確定
     if (selectedIndex >= 0 && suggestions[selectedIndex]) {
       handleSelect(suggestions[selectedIndex])
-    } else if (query.trim()) {
+      return
+    }
+    if (!query.trim()) return
+
+    setShowSuggestions(false)
+    // Enterでの検索でも「エリアを生成」パネルまで到達できるようにする。
+    // 以前は onSearch でカメラ移動のみ行われ、SearchFormローカルの
+    // lastSearchResult が設定されずパネルが出なかった。
+    // 候補が既に表示されていれば先頭を、まだ無ければ即時検索して先頭を
+    // 選択し、候補クリック時と同じ経路（handleSelect）に揃える。
+    if (suggestions.length > 0) {
+      handleSelect(suggestions[0])
+      return
+    }
+    const results = await searchAddress(query.trim())
+    if (results.length > 0) {
+      handleSelect(results[0])
+    } else {
+      // 結果なし時は親に委ねる（「見つかりませんでした」通知は親が表示）
       onSearch?.(query.trim())
-      setShowSuggestions(false)
     }
   }
 

--- a/src/components/SearchForm/SearchForm.test.jsx
+++ b/src/components/SearchForm/SearchForm.test.jsx
@@ -107,4 +107,49 @@ describe('SearchForm', () => {
       expect.objectContaining({ useCustomSize: true, customRadius: 100 })
     )
   })
+
+  it('候補表示中にEnterで検索すると先頭候補が選ばれ「エリアを生成」パネルが開く', async () => {
+    const onSelect = vi.fn()
+    render(<SearchForm onGeneratePolygon={vi.fn()} onSelect={onSelect} onSearch={vi.fn()} />)
+
+    searchAddress.mockResolvedValue([mockSuggestion])
+    const input = screen.getByPlaceholderText(/住所・建物名を検索/)
+    fireEvent.change(input, { target: { value: '中川' } })
+    await waitFor(() => expect(screen.getByText('中川')).toBeInTheDocument())
+
+    // 候補をクリックせずEnter（矢印選択もしていない状態）
+    fireEvent.submit(input.closest('form'))
+
+    await waitFor(() => expect(screen.getByText('エリアを生成')).toBeInTheDocument())
+    expect(onSelect).toHaveBeenCalledWith(mockSuggestion)
+  })
+
+  it('候補未表示でEnter検索した場合も即時検索して先頭候補でパネルが開く', async () => {
+    const onSelect = vi.fn()
+    const onSearch = vi.fn()
+    render(<SearchForm onGeneratePolygon={vi.fn()} onSelect={onSelect} onSearch={onSearch} />)
+
+    // debounce前にEnterするケースを模し、候補が未表示の状態で直接submit
+    searchAddress.mockResolvedValue([mockSuggestion])
+    const input = screen.getByPlaceholderText(/住所・建物名を検索/)
+    // 候補を表示させずにqueryだけ設定するため、changeで値を入れた直後にsubmitを呼ぶ
+    fireEvent.change(input, { target: { value: '中川' } })
+    fireEvent.submit(input.closest('form'))
+
+    await waitFor(() => expect(screen.getByText('エリアを生成')).toBeInTheDocument())
+    expect(onSelect).toHaveBeenCalledWith(mockSuggestion)
+  })
+
+  it('検索結果が0件のEnter時はonSearchにフォールバックする', async () => {
+    const onSearch = vi.fn()
+    render(<SearchForm onGeneratePolygon={vi.fn()} onSearch={onSearch} />)
+
+    searchAddress.mockResolvedValue([])
+    const input = screen.getByPlaceholderText(/住所・建物名を検索/)
+    fireEvent.change(input, { target: { value: '存在しない場所' } })
+    fireEvent.submit(input.closest('form'))
+
+    await waitFor(() => expect(onSearch).toHaveBeenCalledWith('存在しない場所'))
+    expect(screen.queryByText('エリアを生成')).not.toBeInTheDocument()
+  })
 })


### PR DESCRIPTION
## Summary

住所検索で候補をクリックせずEnterキーを押した場合、「エリアを生成」パネルが表示されない問題を修正しました。

## 原因

- 候補クリック時: `onSelect`（親の`handleSearchSelect`）→ SearchFormローカルの`lastSearchResult`がセットされパネル表示
- Enter時: `onSearch`（親の`handleSearch`、カメラ移動のみ）→ `lastSearchResult`がセットされずパネルが出ない

SearchFormローカルの`lastSearchResult`（生成パネル制御）と、MainLayoutの`lastSearchResult`（FlightRequirements用）は別state であることが根因。

## 修正内容

Enter時は、候補が既に表示されていれば先頭を、まだ無ければ即時検索して先頭を選択し、候補クリック時と同じ経路（`handleSelect`）に揃えました。結果0件時は従来通り親の`onSearch`にフォールバックします（「見つかりませんでした」通知は親が表示）。

なお`saveSearchHistory`は書き込むのみでUIから読まれていない（`getSearchHistory`未使用）ため、経路変更による履歴保存の差は実害なしと確認済み。

## Test plan

- [x] `npm run test:run` — 6ファイル89件全pass（Enter経路の回帰テスト3件追加）
- [x] `npm run lint` — 変更ファイル起因の新規エラーなし
- [x] `npm run build` — 成功
- [x] Playwright実機検証 — Enter押下で候補クリック時と同じくカメラ移動＋「エリアを生成」パネル表示を確認

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **改善**
  * Enterキーでの検索時、表示中または取得した候補の先頭を自動選択できるようになりました。
  * 候補がない場合は即時検索を実行し、結果があれば先頭候補を選択します。
  * 検索結果がない場合は従来どおり検索処理へ移行します。
  * IME変換中のEnter操作は引き続き適切に扱われます。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->