### PR TITLE
fix: ポリゴンのクリック時にツールチップを表示しないよう修正

### DIFF
--- a/src/components/Map/Map.jsx
+++ b/src/components/Map/Map.jsx
@@ -1093,19 +1093,8 @@ const Map = ({
 
     if (polygonFeature) {
       const polygonId = polygonFeature.properties.id
+      // クリックは選択のみ（ツールチップはホバー時に表示する仕様。MouseEvents.mdx参照）
       onPolygonSelect?.(polygonId)
-      // クリックでポリゴンツールチップを即時表示
-      const polygon = polygons.find(p => p.id === polygonId)
-      if (polygon) {
-        const area = turf.area(polygon.geometry)
-        const waypointCount = waypoints.filter(wp => wp.polygonId === polygon.id).length
-        setTooltip({
-          isVisible: true,
-          position: { x: e.originalEvent.clientX, y: e.originalEvent.clientY },
-          data: { ...polygon, area, waypointCount },
-          type: 'polygon'
-        })
-      }
       return
     }
 


### PR DESCRIPTION
## Summary

ポリゴン（ウェイポイントを含むエリア）を左クリックすると、選択に加えてツールチップ（エリア名/Waypoint数/面積/作成日）が即時表示される問題を修正しました。

## 背景（調査結果）

- この挙動は **PR #64（`b35ebb1`「ホバーツールチップ機能とルート最適化のWIP化」）で追加**されたもの。それ以前はクリック時は選択のみだった。
- 仕様書 `src/components/Map/MouseEvents.mdx` では「ポリゴンのクリック＝**選択のみ**」「ツールチップ＝**ホバー時（遅延）**」と定義されており、クリック時表示は**未文書化**の挙動。
- ホバー時に同じ内容が出るため、クリック時表示は実質重複。

## 修正内容

`Map.jsx` の `handleClick` のポリゴン分岐から `setTooltip(...)` 呼び出し（12行）を削除し、クリックは `onPolygonSelect` による選択のみに戻しました。ホバー時のツールチップ表示は従来どおり維持。

## Test plan

- [x] `npm run test:run` — 89件全pass
- [x] `npm run build` — 成功
- [x] `npm run lint` — Map.jsx由来の新規エラーなし（既存の未使用setter警告のみ）
- [x] Playwright実機で検証:
  - ポリゴンをクリック → ツールチップ**非表示**（clickTooltip=0）、選択は動作
  - ポリゴンをホバー（3秒）→ ツールチップ**表示**（hoverTooltip=1）